### PR TITLE
feat: Truck Management (Phase 1)

### DIFF
--- a/src/app/(admin)/admin/trucks/page.tsx
+++ b/src/app/(admin)/admin/trucks/page.tsx
@@ -1,0 +1,218 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+import { Plus, Pencil, Trash2, Truck } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { TruckModal } from "@/components/admin/truck-modal"
+import type { Truck as TruckType } from "@/lib/schema"
+
+const STATUS_STYLES: Record<string, string> = {
+  available: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  on_trip: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  maintenance: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  inactive: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  available: "Available",
+  on_trip: "On Trip",
+  maintenance: "Maintenance",
+  inactive: "Inactive",
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  tanker: "Tanker",
+  hazmat: "HazMat Truck",
+  flatbed: "Flatbed",
+  refrigerated: "Refrigerated",
+}
+
+export default function TrucksPage() {
+  const [truckList, setTruckList] = useState<TruckType[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState<TruckType | null>(null)
+  const [deleting, setDeleting] = useState<TruckType | null>(null)
+
+  async function fetchTrucks() {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/admin/trucks")
+      const data = await res.json()
+      setTruckList(data)
+    } catch {
+      toast.error("Failed to load trucks")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchTrucks() }, [])
+
+  function openAdd() {
+    setEditing(null)
+    setModalOpen(true)
+  }
+
+  function openEdit(truck: TruckType) {
+    setEditing(truck)
+    setModalOpen(true)
+  }
+
+  async function handleDelete() {
+    if (!deleting) return
+    try {
+      const res = await fetch(`/api/admin/trucks/${deleting.id}`, { method: "DELETE" })
+      if (!res.ok) throw new Error()
+      toast.success(`"${deleting.name}" deleted`)
+      setDeleting(null)
+      fetchTrucks()
+    } catch {
+      toast.error("Failed to delete truck")
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Truck className="h-6 w-6" />
+            Trucks
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Manage your fleet vehicles — types, plates, and availability status.
+          </p>
+        </div>
+        <Button onClick={openAdd}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Truck
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="border rounded-lg overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>License Plate</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="w-[100px]">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-12 text-muted-foreground">
+                  Loading...
+                </TableCell>
+              </TableRow>
+            ) : truckList.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-12 text-muted-foreground">
+                  <Truck className="h-8 w-8 mx-auto mb-2 opacity-30" />
+                  <p>No trucks in the fleet yet.</p>
+                  <p className="text-xs mt-1">Add your first truck to get started.</p>
+                </TableCell>
+              </TableRow>
+            ) : (
+              truckList.map((truck) => (
+                <TableRow key={truck.id}>
+                  <TableCell className="font-medium">{truck.name}</TableCell>
+                  <TableCell className="font-mono text-sm">{truck.plate}</TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">
+                      {TYPE_LABELS[truck.type] ?? truck.type}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_STYLES[truck.status] ?? ""}`}>
+                      {STATUS_LABELS[truck.status] ?? truck.status}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => openEdit(truck)}
+                        title="Edit"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => setDeleting(truck)}
+                        title="Delete"
+                        className="text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Add / Edit Modal */}
+      <TruckModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        editing={editing}
+        onSuccess={() => {
+          setModalOpen(false)
+          fetchTrucks()
+        }}
+      />
+
+      {/* Delete Confirmation */}
+      <AlertDialog open={!!deleting} onOpenChange={(open) => !open && setDeleting(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete truck?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <strong>&quot;{deleting?.name}&quot;</strong> ({deleting?.plate}) will be permanently deleted.
+              Any trips referencing this truck will lose the association.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/app/api/admin/trucks/[id]/route.ts
+++ b/src/app/api/admin/trucks/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { trucks } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { eq } from "drizzle-orm"
+
+const truckSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  plate: z.string().min(1, "Plate number is required"),
+  type: z.string().min(1, "Vehicle type is required"),
+  status: z.enum(["available", "on_trip", "maintenance", "inactive"]),
+})
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireRole(["admin"])
+    const { id } = await params
+    const body = await req.json()
+    const data = truckSchema.parse(body)
+
+    const [updated] = await db
+      .update(trucks)
+      .set({
+        name: data.name,
+        plate: data.plate,
+        type: data.type,
+        status: data.status,
+      })
+      .where(eq(trucks.id, id))
+      .returning()
+
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(updated)
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireRole(["admin"])
+    const { id } = await params
+    await db.delete(trucks).where(eq(trucks.id, id))
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/admin/trucks/route.ts
+++ b/src/app/api/admin/trucks/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { trucks } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { asc } from "drizzle-orm"
+
+const truckSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  plate: z.string().min(1, "Plate number is required"),
+  type: z.string().min(1, "Vehicle type is required"),
+  status: z.enum(["available", "on_trip", "maintenance", "inactive"]).default("available"),
+})
+
+export async function GET() {
+  try {
+    await requireRole(["admin"])
+    const rows = await db.select().from(trucks).orderBy(asc(trucks.name))
+    return NextResponse.json(rows)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    await requireRole(["admin"])
+    const body = await req.json()
+    const data = truckSchema.parse(body)
+
+    const [truck] = await db.insert(trucks).values({
+      name: data.name,
+      plate: data.plate,
+      type: data.type,
+      status: data.status,
+    }).returning()
+
+    return NextResponse.json(truck, { status: 201 })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/components/admin/truck-modal.tsx
+++ b/src/components/admin/truck-modal.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useForm, Controller } from "react-hook-form"
+import { toast } from "sonner"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { Truck } from "@/lib/schema"
+
+const VEHICLE_TYPES = [
+  { value: "tanker", label: "Tanker" },
+  { value: "hazmat", label: "HazMat Truck" },
+  { value: "flatbed", label: "Flatbed" },
+  { value: "refrigerated", label: "Refrigerated" },
+]
+
+const STATUSES = [
+  { value: "available", label: "Available" },
+  { value: "on_trip", label: "On Trip" },
+  { value: "maintenance", label: "Maintenance" },
+  { value: "inactive", label: "Inactive" },
+]
+
+type FormValues = {
+  name: string
+  plate: string
+  type: string
+  status: string
+}
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  editing: Truck | null
+  onSuccess: () => void
+}
+
+export function TruckModal({ open, onOpenChange, editing, onSuccess }: Props) {
+  const [submitting, setSubmitting] = useState(false)
+
+  const { register, handleSubmit, control, reset, formState: { errors } } = useForm<FormValues>({
+    defaultValues: {
+      name: "",
+      plate: "",
+      type: "",
+      status: "available",
+    },
+  })
+
+  useEffect(() => {
+    if (open) {
+      reset(
+        editing
+          ? {
+              name: editing.name,
+              plate: editing.plate,
+              type: editing.type,
+              status: editing.status,
+            }
+          : { name: "", plate: "", type: "", status: "available" }
+      )
+    }
+  }, [open, editing, reset])
+
+  async function onSubmit(values: FormValues) {
+    setSubmitting(true)
+    try {
+      const url = editing ? `/api/admin/trucks/${editing.id}` : "/api/admin/trucks"
+      const method = editing ? "PUT" : "POST"
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      })
+
+      if (!res.ok) {
+        const err = await res.json()
+        toast.error(err.error ?? "Something went wrong")
+        return
+      }
+
+      toast.success(editing ? "Truck updated" : "Truck added")
+      onSuccess()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit Truck" : "Add Truck"}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Name */}
+          <div className="space-y-1">
+            <Label htmlFor="name">Truck Name *</Label>
+            <Input
+              id="name"
+              {...register("name", { required: "Name is required" })}
+              placeholder="e.g. Unit 42"
+            />
+            {errors.name && (
+              <p className="text-xs text-destructive">{errors.name.message}</p>
+            )}
+          </div>
+
+          {/* Plate */}
+          <div className="space-y-1">
+            <Label htmlFor="plate">License Plate *</Label>
+            <Input
+              id="plate"
+              {...register("plate", { required: "Plate number is required" })}
+              placeholder="e.g. ABC-1234"
+            />
+            {errors.plate && (
+              <p className="text-xs text-destructive">{errors.plate.message}</p>
+            )}
+          </div>
+
+          {/* Type */}
+          <div className="space-y-1">
+            <Label>Vehicle Type *</Label>
+            <Controller
+              name="type"
+              control={control}
+              rules={{ required: "Vehicle type is required" }}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select vehicle type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VEHICLE_TYPES.map((v) => (
+                      <SelectItem key={v.value} value={v.value}>
+                        {v.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.type && (
+              <p className="text-xs text-destructive">{errors.type.message}</p>
+            )}
+          </div>
+
+          {/* Status */}
+          <div className="space-y-1">
+            <Label>Status *</Label>
+            <Controller
+              name="status"
+              control={control}
+              rules={{ required: "Status is required" }}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STATUSES.map((s) => (
+                      <SelectItem key={s.value} value={s.value}>
+                        {s.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.status && (
+              <p className="text-xs text-destructive">{errors.status.message}</p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving..." : editing ? "Save Changes" : "Add Truck"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

Implements the Truck Management feature for admin users.

### What's included
- **API routes** — GET, POST (`/api/admin/trucks`), PUT, DELETE (`/api/admin/trucks/[id]`) with Zod validation and `requireRole(["admin"])` guard
- **Admin page** — `/admin/trucks` table with columns: Name, License Plate, Type, Status, Actions
- **Status badges** — color-coded (green=Available, blue=On Trip, yellow=Maintenance, grey=Inactive)
- **Add/Edit modal** — `TruckModal` with truck name, license plate, vehicle type selector, and status selector
- **Delete confirmation** — AlertDialog before destructive delete

### Test plan
- [ ] `/admin/trucks` shows the table (seeded trucks visible)
- [ ] "Add Truck" opens modal — fill fields, submit → row appears
- [ ] Edit button pre-fills modal → save updates row
- [ ] Delete button shows confirmation → confirm → row removed
- [ ] Missing required fields show validation errors
- [ ] Duplicate plate number returns an error
- [ ] Non-admin users redirected away from `/admin/trucks`
