### PR TITLE
feat: Driver Profiles (Phase 1)

### DIFF
--- a/src/app/(admin)/admin/drivers/page.tsx
+++ b/src/app/(admin)/admin/drivers/page.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+import { Plus, Pencil, Trash2, Users } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { DriverModal } from "@/components/admin/driver-modal"
+
+type DriverRow = {
+  id: string
+  userId: string
+  licenseNumber: string
+  certifications: string[]
+  status: string
+  userName: string | null
+  userEmail: string | null
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  available: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  on_shift: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  driving: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  delivering: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+  off_duty: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  available: "Available",
+  on_shift: "On Shift",
+  driving: "Driving",
+  delivering: "Delivering",
+  off_duty: "Off Duty",
+}
+
+const CERT_LABELS: Record<string, string> = {
+  hazmat: "HazMat",
+  tanker: "Tanker",
+  twic: "TWIC",
+  acid: "Acid",
+  compressed_gas: "Comp. Gas",
+  explosives_precursor: "Explosives",
+}
+
+export default function DriversPage() {
+  const [driverList, setDriverList] = useState<DriverRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState<DriverRow | null>(null)
+  const [deleting, setDeleting] = useState<DriverRow | null>(null)
+
+  async function fetchDrivers() {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/admin/drivers")
+      const data = await res.json()
+      setDriverList(data)
+    } catch {
+      toast.error("Failed to load drivers")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchDrivers() }, [])
+
+  function openAdd() {
+    setEditing(null)
+    setModalOpen(true)
+  }
+
+  function openEdit(driver: DriverRow) {
+    setEditing(driver)
+    setModalOpen(true)
+  }
+
+  async function handleDelete() {
+    if (!deleting) return
+    try {
+      const res = await fetch(`/api/admin/drivers/${deleting.id}`, { method: "DELETE" })
+      if (!res.ok) throw new Error()
+      toast.success(`Driver profile for "${deleting.userName}" deleted`)
+      setDeleting(null)
+      fetchDrivers()
+    } catch {
+      toast.error("Failed to delete driver profile")
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Users className="h-6 w-6" />
+            Drivers
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Manage driver profiles — licenses, certifications, and availability.
+          </p>
+        </div>
+        <Button onClick={openAdd}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Driver
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="border rounded-lg overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>License Number</TableHead>
+              <TableHead>Certifications</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="w-[100px]">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center py-12 text-muted-foreground">
+                  Loading...
+                </TableCell>
+              </TableRow>
+            ) : driverList.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center py-12 text-muted-foreground">
+                  <Users className="h-8 w-8 mx-auto mb-2 opacity-30" />
+                  <p>No driver profiles yet.</p>
+                  <p className="text-xs mt-1">Add your first driver to get started.</p>
+                </TableCell>
+              </TableRow>
+            ) : (
+              driverList.map((driver) => (
+                <TableRow key={driver.id}>
+                  <TableCell className="font-medium">{driver.userName ?? "—"}</TableCell>
+                  <TableCell className="text-muted-foreground text-sm">{driver.userEmail ?? "—"}</TableCell>
+                  <TableCell className="font-mono text-sm">{driver.licenseNumber}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {driver.certifications.length === 0 ? (
+                        <span className="text-muted-foreground text-sm">None</span>
+                      ) : (
+                        driver.certifications.map((cert) => (
+                          <Badge key={cert} variant="outline" className="text-xs">
+                            {CERT_LABELS[cert] ?? cert}
+                          </Badge>
+                        ))
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_STYLES[driver.status] ?? ""}`}>
+                      {STATUS_LABELS[driver.status] ?? driver.status}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => openEdit(driver)}
+                        title="Edit"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => setDeleting(driver)}
+                        title="Delete"
+                        className="text-destructive hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Add / Edit Modal */}
+      <DriverModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        editing={editing}
+        onSuccess={() => {
+          setModalOpen(false)
+          fetchDrivers()
+        }}
+      />
+
+      {/* Delete Confirmation */}
+      <AlertDialog open={!!deleting} onOpenChange={(open) => !open && setDeleting(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete driver profile?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The driver profile for <strong>&quot;{deleting?.userName}&quot;</strong> will be permanently deleted.
+              The user account will remain, but they will lose their driver profile and certification records.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/app/api/admin/drivers/[id]/route.ts
+++ b/src/app/api/admin/drivers/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { drivers } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { eq } from "drizzle-orm"
+
+const driverSchema = z.object({
+  licenseNumber: z.string().min(1, "License number is required"),
+  certifications: z.array(z.string()).default([]),
+  status: z.enum(["available", "on_shift", "driving", "delivering", "off_duty"]),
+})
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireRole(["admin"])
+    const { id } = await params
+    const body = await req.json()
+    const data = driverSchema.parse(body)
+
+    const [updated] = await db
+      .update(drivers)
+      .set({
+        licenseNumber: data.licenseNumber,
+        certifications: data.certifications,
+        status: data.status,
+      })
+      .where(eq(drivers.id, id))
+      .returning()
+
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(updated)
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireRole(["admin"])
+    const { id } = await params
+    await db.delete(drivers).where(eq(drivers.id, id))
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/admin/drivers/route.ts
+++ b/src/app/api/admin/drivers/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { drivers, user } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { eq } from "drizzle-orm"
+
+const driverSchema = z.object({
+  userId: z.string().min(1, "User is required"),
+  licenseNumber: z.string().min(1, "License number is required"),
+  certifications: z.array(z.string()).default([]),
+  status: z.enum(["available", "on_shift", "driving", "delivering", "off_duty"]).default("available"),
+})
+
+export async function GET() {
+  try {
+    await requireRole(["admin"])
+    const rows = await db
+      .select({
+        id: drivers.id,
+        userId: drivers.userId,
+        licenseNumber: drivers.licenseNumber,
+        certifications: drivers.certifications,
+        status: drivers.status,
+        createdAt: drivers.createdAt,
+        updatedAt: drivers.updatedAt,
+        userName: user.name,
+        userEmail: user.email,
+      })
+      .from(drivers)
+      .leftJoin(user, eq(drivers.userId, user.id))
+      .orderBy(user.name)
+    return NextResponse.json(rows)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    await requireRole(["admin"])
+    const body = await req.json()
+    const data = driverSchema.parse(body)
+
+    const [driver] = await db.insert(drivers).values({
+      userId: data.userId,
+      licenseNumber: data.licenseNumber,
+      certifications: data.certifications,
+      status: data.status,
+    }).returning()
+
+    return NextResponse.json(driver, { status: 201 })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    // Unique constraint on userId
+    if (err instanceof Error && err.message.includes("unique")) {
+      return NextResponse.json({ error: "This user already has a driver profile" }, { status: 409 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/admin/users/without-driver/route.ts
+++ b/src/app/api/admin/users/without-driver/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { user, drivers } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { notInArray } from "drizzle-orm"
+import { asc } from "drizzle-orm"
+
+export async function GET() {
+  try {
+    await requireRole(["admin"])
+
+    // Get all user IDs that already have a driver profile
+    const existing = await db.select({ userId: drivers.userId }).from(drivers)
+    const existingUserIds = existing.map((r) => r.userId)
+
+    const users =
+      existingUserIds.length > 0
+        ? await db
+            .select({ id: user.id, name: user.name, email: user.email })
+            .from(user)
+            .where(notInArray(user.id, existingUserIds))
+            .orderBy(asc(user.name))
+        : await db
+            .select({ id: user.id, name: user.name, email: user.email })
+            .from(user)
+            .orderBy(asc(user.name))
+
+    return NextResponse.json(users)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/components/admin/driver-modal.tsx
+++ b/src/components/admin/driver-modal.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useForm, Controller } from "react-hook-form"
+import { toast } from "sonner"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Checkbox } from "@/components/ui/checkbox"
+
+const CERTIFICATIONS = [
+  { value: "hazmat", label: "HazMat Endorsement" },
+  { value: "tanker", label: "Tanker Endorsement" },
+  { value: "twic", label: "TWIC Card" },
+  { value: "acid", label: "Acid/Corrosive Handling" },
+  { value: "compressed_gas", label: "Compressed Gas" },
+  { value: "explosives_precursor", label: "Explosives Precursor" },
+]
+
+const STATUSES = [
+  { value: "available", label: "Available" },
+  { value: "on_shift", label: "On Shift" },
+  { value: "driving", label: "Driving" },
+  { value: "delivering", label: "Delivering" },
+  { value: "off_duty", label: "Off Duty" },
+]
+
+type DriverRow = {
+  id: string
+  userId: string
+  licenseNumber: string
+  certifications: string[]
+  status: string
+  userName: string | null
+  userEmail: string | null
+}
+
+type UserOption = { id: string; name: string; email: string }
+
+type FormValues = {
+  userId: string
+  licenseNumber: string
+  certifications: string[]
+  status: string
+}
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  editing: DriverRow | null
+  onSuccess: () => void
+}
+
+export function DriverModal({ open, onOpenChange, editing, onSuccess }: Props) {
+  const [submitting, setSubmitting] = useState(false)
+  const [availableUsers, setAvailableUsers] = useState<UserOption[]>([])
+
+  const { register, handleSubmit, control, reset, formState: { errors } } = useForm<FormValues>({
+    defaultValues: {
+      userId: "",
+      licenseNumber: "",
+      certifications: [],
+      status: "available",
+    },
+  })
+
+  useEffect(() => {
+    if (open) {
+      reset(
+        editing
+          ? {
+              userId: editing.userId,
+              licenseNumber: editing.licenseNumber,
+              certifications: editing.certifications,
+              status: editing.status,
+            }
+          : { userId: "", licenseNumber: "", certifications: [], status: "available" }
+      )
+      if (!editing) {
+        fetch("/api/admin/users/without-driver")
+          .then((r) => r.json())
+          .then(setAvailableUsers)
+          .catch(() => toast.error("Failed to load users"))
+      }
+    }
+  }, [open, editing, reset])
+
+  async function onSubmit(values: FormValues) {
+    setSubmitting(true)
+    try {
+      const url = editing ? `/api/admin/drivers/${editing.id}` : "/api/admin/drivers"
+      const method = editing ? "PUT" : "POST"
+      const body = editing
+        ? { licenseNumber: values.licenseNumber, certifications: values.certifications, status: values.status }
+        : values
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+
+      if (!res.ok) {
+        const err = await res.json()
+        toast.error(err.error ?? "Something went wrong")
+        return
+      }
+
+      toast.success(editing ? "Driver profile updated" : "Driver profile created")
+      onSuccess()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit Driver Profile" : "Add Driver Profile"}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* User (add mode only) */}
+          {editing ? (
+            <div className="space-y-1">
+              <Label>User</Label>
+              <p className="text-sm text-muted-foreground">
+                {editing.userName} ({editing.userEmail})
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <Label>User *</Label>
+              <Controller
+                name="userId"
+                control={control}
+                rules={{ required: "User is required" }}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a user" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableUsers.length === 0 ? (
+                        <SelectItem value="_none" disabled>
+                          No users without a driver profile
+                        </SelectItem>
+                      ) : (
+                        availableUsers.map((u) => (
+                          <SelectItem key={u.id} value={u.id}>
+                            {u.name} — {u.email}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              {errors.userId && (
+                <p className="text-xs text-destructive">{errors.userId.message}</p>
+              )}
+            </div>
+          )}
+
+          {/* License Number */}
+          <div className="space-y-1">
+            <Label htmlFor="licenseNumber">License Number *</Label>
+            <Input
+              id="licenseNumber"
+              {...register("licenseNumber", { required: "License number is required" })}
+              placeholder="e.g. DL-123456"
+            />
+            {errors.licenseNumber && (
+              <p className="text-xs text-destructive">{errors.licenseNumber.message}</p>
+            )}
+          </div>
+
+          {/* Certifications */}
+          <div className="space-y-2">
+            <Label>Certifications</Label>
+            <Controller
+              name="certifications"
+              control={control}
+              render={({ field }) => (
+                <div className="grid grid-cols-2 gap-2">
+                  {CERTIFICATIONS.map((cert) => {
+                    const checked = field.value.includes(cert.value)
+                    return (
+                      <label
+                        key={cert.value}
+                        className="flex items-center gap-2 text-sm cursor-pointer"
+                      >
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(val) => {
+                            if (val) {
+                              field.onChange([...field.value, cert.value])
+                            } else {
+                              field.onChange(field.value.filter((v) => v !== cert.value))
+                            }
+                          }}
+                        />
+                        {cert.label}
+                      </label>
+                    )
+                  })}
+                </div>
+              )}
+            />
+          </div>
+
+          {/* Status */}
+          <div className="space-y-1">
+            <Label>Status *</Label>
+            <Controller
+              name="status"
+              control={control}
+              rules={{ required: "Status is required" }}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STATUSES.map((s) => (
+                      <SelectItem key={s.value} value={s.value}>
+                        {s.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.status && (
+              <p className="text-xs text-destructive">{errors.status.message}</p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving..." : editing ? "Save Changes" : "Add Driver"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

Implements the Driver Profiles feature for admin users.

### What's included
- **API routes** — GET, POST (`/api/admin/drivers`), PUT, DELETE (`/api/admin/drivers/[id]`) with Zod validation and `requireRole(["admin"])` guard
- **User lookup endpoint** — `/api/admin/users/without-driver` returns users who don't yet have a driver profile (used in the Add modal)
- **Admin page** — `/admin/drivers` table with columns: Name, Email, License Number, Certifications, Status, Actions
- **Status badges** — color-coded (green=Available, blue=On Shift, purple=Driving, orange=Delivering, grey=Off Duty)
- **Add modal** — user selector (filtered to users without profiles), license number, certifications checkboxes, status
- **Edit modal** — shows linked user as read-only, edits license, certifications, status
- **Delete confirmation** — AlertDialog noting the user account remains but profile is removed

### Test plan
- [ ] `/admin/drivers` shows the table
- [ ] "Add Driver" modal shows only users without existing profiles
- [ ] Create a driver profile → row appears with correct name/email/certs
- [ ] Edit updates license, certifications, and status
- [ ] Delete shows confirmation → removes profile but user account remains
- [ ] Non-admin users redirected away from `/admin/drivers`
