### PR TITLE
feat: Trip Creation & Status Management (Phase 2)

### DIFF
--- a/src/app/(dispatcher)/dispatch/trips/page.tsx
+++ b/src/app/(dispatcher)/dispatch/trips/page.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+import { Plus, MapPin, ChevronDown } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { TripCreateModal } from "@/components/dispatch/trip-create-modal"
+import type { ChemicalLoad } from "@/lib/schema"
+
+type TripRow = {
+  id: string
+  status: string
+  origin: string
+  destination: string
+  scheduledAt: string | null
+  truckName: string | null
+  truckPlate: string | null
+  driverName: string | null
+  loadName: string | null
+  loadHazardClass: string | null
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  assigned: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  in_progress: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  delivered: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  cancelled: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: "Draft",
+  assigned: "Assigned",
+  in_progress: "In Progress",
+  delivered: "Delivered",
+  cancelled: "Cancelled",
+}
+
+const NEXT_STATUSES: Record<string, { value: string; label: string }[]> = {
+  assigned: [
+    { value: "in_progress", label: "Mark In Progress" },
+    { value: "cancelled", label: "Cancel Trip" },
+  ],
+  in_progress: [
+    { value: "delivered", label: "Mark Delivered" },
+    { value: "cancelled", label: "Cancel Trip" },
+  ],
+}
+
+export default function TripsPage() {
+  const [tripList, setTripList] = useState<TripRow[]>([])
+  const [loads, setLoads] = useState<ChemicalLoad[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [cancelling, setCancelling] = useState<TripRow | null>(null)
+
+  async function fetchTrips() {
+    setLoading(true)
+    try {
+      const [tripsRes, loadsRes] = await Promise.all([
+        fetch("/api/dispatch/trips"),
+        fetch("/api/admin/chemical-loads"),
+      ])
+      setTripList(await tripsRes.json())
+      setLoads(await loadsRes.json())
+    } catch {
+      toast.error("Failed to load trips")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchTrips() }, [])
+
+  async function updateStatus(tripId: string, status: string) {
+    if (status === "cancelled") {
+      const trip = tripList.find((t) => t.id === tripId)
+      if (trip) { setCancelling(trip); return }
+    }
+    await patchStatus(tripId, status)
+  }
+
+  async function patchStatus(tripId: string, status: string) {
+    try {
+      const res = await fetch(`/api/dispatch/trips/${tripId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      })
+      if (!res.ok) throw new Error()
+      toast.success(`Trip marked as ${STATUS_LABELS[status]}`)
+      fetchTrips()
+    } catch {
+      toast.error("Failed to update trip status")
+    }
+  }
+
+  function formatDate(iso: string | null) {
+    if (!iso) return "—"
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+    })
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <MapPin className="h-6 w-6" />
+            Trips
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Create and manage dispatch trips across the fleet.
+          </p>
+        </div>
+        <Button onClick={() => setModalOpen(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          New Trip
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="border rounded-lg overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Load</TableHead>
+              <TableHead>Route</TableHead>
+              <TableHead>Truck</TableHead>
+              <TableHead>Driver</TableHead>
+              <TableHead>Scheduled</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="w-[100px]">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center py-12 text-muted-foreground">
+                  Loading...
+                </TableCell>
+              </TableRow>
+            ) : tripList.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center py-12 text-muted-foreground">
+                  <MapPin className="h-8 w-8 mx-auto mb-2 opacity-30" />
+                  <p>No trips yet.</p>
+                  <p className="text-xs mt-1">Create your first trip to get started.</p>
+                </TableCell>
+              </TableRow>
+            ) : (
+              tripList.map((trip) => (
+                <TableRow key={trip.id}>
+                  <TableCell>
+                    <div>
+                      <p className="font-medium text-sm">{trip.loadName ?? "—"}</p>
+                      {trip.loadHazardClass && (
+                        <p className="text-xs text-muted-foreground">Class {trip.loadHazardClass}</p>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="text-sm">
+                      <p>{trip.origin}</p>
+                      <p className="text-muted-foreground">→ {trip.destination}</p>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="text-sm">
+                      <p>{trip.truckName ?? "—"}</p>
+                      {trip.truckPlate && (
+                        <p className="text-xs font-mono text-muted-foreground">{trip.truckPlate}</p>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-sm">{trip.driverName ?? "—"}</TableCell>
+                  <TableCell className="text-sm">{formatDate(trip.scheduledAt)}</TableCell>
+                  <TableCell>
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_STYLES[trip.status] ?? ""}`}>
+                      {STATUS_LABELS[trip.status] ?? trip.status}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    {NEXT_STATUSES[trip.status] ? (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button size="sm" variant="outline" className="h-7 text-xs gap-1">
+                            Update <ChevronDown className="h-3 w-3" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {NEXT_STATUSES[trip.status].map((next, i) => (
+                            <>
+                              {i > 0 && <DropdownMenuSeparator key={`sep-${i}`} />}
+                              <DropdownMenuItem
+                                key={next.value}
+                                onClick={() => updateStatus(trip.id, next.value)}
+                                className={next.value === "cancelled" ? "text-destructive" : ""}
+                              >
+                                {next.label}
+                              </DropdownMenuItem>
+                            </>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Create Modal */}
+      <TripCreateModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        loads={loads}
+        onSuccess={() => {
+          setModalOpen(false)
+          fetchTrips()
+        }}
+      />
+
+      {/* Cancel Confirmation */}
+      <AlertDialog open={!!cancelling} onOpenChange={(open) => !open && setCancelling(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel this trip?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The trip from <strong>{cancelling?.origin}</strong> to <strong>{cancelling?.destination}</strong> will be marked as cancelled.
+              This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Trip</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => { patchStatus(cancelling!.id, "cancelled"); setCancelling(null) }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Cancel Trip
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/app/api/dispatch/eligible-resources/route.ts
+++ b/src/app/api/dispatch/eligible-resources/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { trucks, drivers, chemicalLoads, user } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { eq, inArray } from "drizzle-orm"
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole(["dispatcher", "admin"])
+    const { searchParams } = new URL(req.url)
+    const loadId = searchParams.get("loadId")
+
+    if (!loadId) {
+      return NextResponse.json({ error: "loadId is required" }, { status: 400 })
+    }
+
+    const [load] = await db
+      .select()
+      .from(chemicalLoads)
+      .where(eq(chemicalLoads.id, loadId))
+
+    if (!load) {
+      return NextResponse.json({ error: "Load not found" }, { status: 404 })
+    }
+
+    // Trucks: match required vehicle type and available status
+    const eligibleTrucks = await db
+      .select()
+      .from(trucks)
+      .where(eq(trucks.type, load.requiredVehicleType))
+
+    // Drivers: must hold all required certifications
+    const allDrivers = await db
+      .select({
+        id: drivers.id,
+        userId: drivers.userId,
+        licenseNumber: drivers.licenseNumber,
+        certifications: drivers.certifications,
+        status: drivers.status,
+        userName: user.name,
+        userEmail: user.email,
+      })
+      .from(drivers)
+      .leftJoin(user, eq(drivers.userId, user.id))
+
+    const required = load.requiredCertifications
+    const eligibleDrivers = allDrivers.filter((d) =>
+      required.every((cert) => d.certifications.includes(cert))
+    )
+
+    return NextResponse.json({ trucks: eligibleTrucks, drivers: eligibleDrivers, load })
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/dispatch/trips/[id]/route.ts
+++ b/src/app/api/dispatch/trips/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { trips } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { eq } from "drizzle-orm"
+
+const statusSchema = z.object({
+  status: z.enum(["draft", "assigned", "in_progress", "delivered", "cancelled"]),
+})
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireRole(["dispatcher", "admin"])
+    const { id } = await params
+    const body = await req.json()
+    const { status } = statusSchema.parse(body)
+
+    const now = new Date()
+    const [updated] = await db
+      .update(trips)
+      .set({
+        status,
+        ...(status === "in_progress" ? { startedAt: now } : {}),
+        ...(status === "delivered" ? { deliveredAt: now } : {}),
+      })
+      .where(eq(trips.id, id))
+      .returning()
+
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(updated)
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireRole(["dispatcher", "admin"])
+    const { id } = await params
+    await db.delete(trips).where(eq(trips.id, id))
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/dispatch/trips/route.ts
+++ b/src/app/api/dispatch/trips/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { trips, trucks, drivers, chemicalLoads, user } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { desc, eq } from "drizzle-orm"
+
+const tripSchema = z.object({
+  loadId: z.string().min(1, "Chemical load is required"),
+  truckId: z.string().min(1, "Truck is required"),
+  driverId: z.string().min(1, "Driver is required"),
+  origin: z.string().min(1, "Origin is required"),
+  destination: z.string().min(1, "Destination is required"),
+  scheduledAt: z.string().min(1, "Scheduled date/time is required"),
+  notes: z.string().optional().nullable(),
+})
+
+export async function GET() {
+  try {
+    await requireRole(["dispatcher", "admin"])
+
+    const rows = await db
+      .select({
+        id: trips.id,
+        status: trips.status,
+        origin: trips.origin,
+        destination: trips.destination,
+        scheduledAt: trips.scheduledAt,
+        startedAt: trips.startedAt,
+        deliveredAt: trips.deliveredAt,
+        notes: trips.notes,
+        createdAt: trips.createdAt,
+        truckId: trips.truckId,
+        truckName: trucks.name,
+        truckPlate: trucks.plate,
+        driverId: trips.driverId,
+        driverName: user.name,
+        loadId: trips.loadId,
+        loadName: chemicalLoads.name,
+        loadHazardClass: chemicalLoads.hazardClass,
+      })
+      .from(trips)
+      .leftJoin(trucks, eq(trips.truckId, trucks.id))
+      .leftJoin(drivers, eq(trips.driverId, drivers.id))
+      .leftJoin(user, eq(drivers.userId, user.id))
+      .leftJoin(chemicalLoads, eq(trips.loadId, chemicalLoads.id))
+      .orderBy(desc(trips.scheduledAt))
+
+    return NextResponse.json(rows)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { session } = await requireRole(["dispatcher", "admin"])
+    const body = await req.json()
+    const data = tripSchema.parse(body)
+
+    const [trip] = await db.insert(trips).values({
+      loadId: data.loadId,
+      truckId: data.truckId,
+      driverId: data.driverId,
+      origin: data.origin,
+      destination: data.destination,
+      scheduledAt: new Date(data.scheduledAt),
+      notes: data.notes ?? null,
+      status: "assigned",
+      createdBy: session.user.id,
+    }).returning()
+
+    return NextResponse.json(trip, { status: 201 })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/components/dispatch/trip-create-modal.tsx
+++ b/src/components/dispatch/trip-create-modal.tsx
@@ -1,0 +1,321 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useForm, Controller } from "react-hook-form"
+import { toast } from "sonner"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { AlertCircle } from "lucide-react"
+import type { ChemicalLoad, Truck } from "@/lib/schema"
+
+type DriverOption = {
+  id: string
+  userId: string
+  licenseNumber: string
+  certifications: string[]
+  status: string
+  userName: string | null
+  userEmail: string | null
+}
+
+type EligibleResources = {
+  trucks: Truck[]
+  drivers: DriverOption[]
+  load: ChemicalLoad
+}
+
+type FormValues = {
+  loadId: string
+  truckId: string
+  driverId: string
+  origin: string
+  destination: string
+  scheduledAt: string
+  notes: string
+}
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  loads: ChemicalLoad[]
+  onSuccess: () => void
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  available: "Available",
+  on_shift: "On Shift",
+  driving: "Driving",
+  delivering: "Delivering",
+  off_duty: "Off Duty",
+  on_trip: "On Trip",
+  maintenance: "Maintenance",
+  inactive: "Inactive",
+}
+
+export function TripCreateModal({ open, onOpenChange, loads, onSuccess }: Props) {
+  const [submitting, setSubmitting] = useState(false)
+  const [resources, setResources] = useState<EligibleResources | null>(null)
+  const [loadingResources, setLoadingResources] = useState(false)
+
+  const { register, handleSubmit, control, watch, reset, setValue, formState: { errors } } =
+    useForm<FormValues>({
+      defaultValues: {
+        loadId: "",
+        truckId: "",
+        driverId: "",
+        origin: "",
+        destination: "",
+        scheduledAt: "",
+        notes: "",
+      },
+    })
+
+  const selectedLoadId = watch("loadId")
+
+  // Reset truck/driver when load changes
+  useEffect(() => {
+    setValue("truckId", "")
+    setValue("driverId", "")
+    setResources(null)
+
+    if (!selectedLoadId) return
+
+    setLoadingResources(true)
+    fetch(`/api/dispatch/eligible-resources?loadId=${selectedLoadId}`)
+      .then((r) => r.json())
+      .then(setResources)
+      .catch(() => toast.error("Failed to load eligible trucks and drivers"))
+      .finally(() => setLoadingResources(false))
+  }, [selectedLoadId, setValue])
+
+  useEffect(() => {
+    if (open) {
+      reset()
+      setResources(null)
+    }
+  }, [open, reset])
+
+  async function onSubmit(values: FormValues) {
+    setSubmitting(true)
+    try {
+      const res = await fetch("/api/dispatch/trips", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      })
+      if (!res.ok) {
+        const err = await res.json()
+        toast.error(err.error ?? "Something went wrong")
+        return
+      }
+      toast.success("Trip created and driver notified")
+      onSuccess()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create New Trip</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Chemical Load */}
+          <div className="space-y-1">
+            <Label>Chemical Load *</Label>
+            <Controller
+              name="loadId"
+              control={control}
+              rules={{ required: "Chemical load is required" }}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select chemical load" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {loads.map((l) => (
+                      <SelectItem key={l.id} value={l.id}>
+                        {l.name} — Class {l.hazardClass}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.loadId && <p className="text-xs text-destructive">{errors.loadId.message}</p>}
+          </div>
+
+          {/* Load info / requirements */}
+          {resources?.load && (
+            <div className="rounded-md border p-3 space-y-1 text-sm bg-muted/40">
+              <p className="font-medium">{resources.load.name}</p>
+              <div className="flex flex-wrap gap-1 text-xs text-muted-foreground">
+                <span>Hazard Class {resources.load.hazardClass}</span>
+                {resources.load.unNumber && <span>· {resources.load.unNumber}</span>}
+                <span>· Requires {resources.load.requiredVehicleType}</span>
+              </div>
+              {resources.load.requiredCertifications.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {resources.load.requiredCertifications.map((c) => (
+                    <Badge key={c} variant="outline" className="text-xs">{c}</Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Truck */}
+          <div className="space-y-1">
+            <Label>Truck *</Label>
+            {loadingResources ? (
+              <p className="text-xs text-muted-foreground">Loading eligible trucks...</p>
+            ) : (
+              <Controller
+                name="truckId"
+                control={control}
+                rules={{ required: "Truck is required" }}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} disabled={!resources}>
+                    <SelectTrigger>
+                      <SelectValue placeholder={resources ? "Select truck" : "Select a load first"} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {resources?.trucks.length === 0 ? (
+                        <SelectItem value="_none" disabled>No eligible trucks available</SelectItem>
+                      ) : (
+                        resources?.trucks.map((t) => (
+                          <SelectItem key={t.id} value={t.id}>
+                            {t.name} ({t.plate}) — {STATUS_LABELS[t.status] ?? t.status}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            )}
+            {resources?.trucks.length === 0 && selectedLoadId && (
+              <p className="text-xs text-destructive flex items-center gap-1">
+                <AlertCircle className="h-3 w-3" />
+                No trucks of the required type are available
+              </p>
+            )}
+            {errors.truckId && <p className="text-xs text-destructive">{errors.truckId.message}</p>}
+          </div>
+
+          {/* Driver */}
+          <div className="space-y-1">
+            <Label>Driver *</Label>
+            {loadingResources ? (
+              <p className="text-xs text-muted-foreground">Loading eligible drivers...</p>
+            ) : (
+              <Controller
+                name="driverId"
+                control={control}
+                rules={{ required: "Driver is required" }}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} disabled={!resources}>
+                    <SelectTrigger>
+                      <SelectValue placeholder={resources ? "Select driver" : "Select a load first"} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {resources?.drivers.length === 0 ? (
+                        <SelectItem value="_none" disabled>No certified drivers available</SelectItem>
+                      ) : (
+                        resources?.drivers.map((d) => (
+                          <SelectItem key={d.id} value={d.id}>
+                            {d.userName} — {STATUS_LABELS[d.status] ?? d.status}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            )}
+            {resources?.drivers.length === 0 && selectedLoadId && (
+              <p className="text-xs text-destructive flex items-center gap-1">
+                <AlertCircle className="h-3 w-3" />
+                No drivers hold the required certifications
+              </p>
+            )}
+            {errors.driverId && <p className="text-xs text-destructive">{errors.driverId.message}</p>}
+          </div>
+
+          {/* Origin */}
+          <div className="space-y-1">
+            <Label htmlFor="origin">Origin *</Label>
+            <Input
+              id="origin"
+              {...register("origin", { required: "Origin is required" })}
+              placeholder="e.g. Houston, TX"
+            />
+            {errors.origin && <p className="text-xs text-destructive">{errors.origin.message}</p>}
+          </div>
+
+          {/* Destination */}
+          <div className="space-y-1">
+            <Label htmlFor="destination">Destination *</Label>
+            <Input
+              id="destination"
+              {...register("destination", { required: "Destination is required" })}
+              placeholder="e.g. Dallas, TX"
+            />
+            {errors.destination && <p className="text-xs text-destructive">{errors.destination.message}</p>}
+          </div>
+
+          {/* Scheduled At */}
+          <div className="space-y-1">
+            <Label htmlFor="scheduledAt">Scheduled Departure *</Label>
+            <Input
+              id="scheduledAt"
+              type="datetime-local"
+              {...register("scheduledAt", { required: "Scheduled time is required" })}
+            />
+            {errors.scheduledAt && <p className="text-xs text-destructive">{errors.scheduledAt.message}</p>}
+          </div>
+
+          {/* Notes */}
+          <div className="space-y-1">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea
+              id="notes"
+              {...register("notes")}
+              placeholder="Any special instructions..."
+              rows={2}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Creating..." : "Create Trip"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

Implements trip creation and status management for dispatchers.

### What's included
- **Eligible resources API** — `GET /api/dispatch/eligible-resources?loadId=` returns trucks filtered by required vehicle type and drivers filtered by required certifications
- **Trips API** — `GET /api/dispatch/trips` (list with joins), `POST /api/dispatch/trips` (create), `PATCH /api/dispatch/trips/[id]` (status update), `DELETE /api/dispatch/trips/[id]`
- **Trip creation modal** — select chemical load → auto-filters eligible trucks and certified drivers → enter origin, destination, scheduled time, notes. Shows warnings when no eligible trucks or drivers exist
- **Trips list page** — `/dispatch/trips` table with Load, Route, Truck, Driver, Scheduled time, and Status columns
- **Status management** — dropdown to advance trip through lifecycle: `assigned → in_progress → delivered`, with cancel confirmation dialog
- **Color-coded status badges** — grey=Draft, blue=Assigned, purple=In Progress, green=Delivered, red=Cancelled

### Test plan
- [ ] `/dispatch/trips` loads and shows empty state
- [ ] "New Trip" opens modal with chemical load selector
- [ ] Selecting a load filters trucks to matching vehicle type
- [ ] Selecting a load filters drivers to those with all required certifications
- [ ] Warning shown when no eligible trucks or drivers available
- [ ] Creating a trip adds a row with status "Assigned"
- [ ] "Update" dropdown advances status correctly
- [ ] Cancelling a trip shows confirmation before changing status
- [ ] Non-dispatcher/admin users redirected away
