### PR TITLE
feat: Driver Trip Detail Page (Phase 3)

### DIFF
--- a/src/app/(driver)/driver/trips/[id]/page.tsx
+++ b/src/app/(driver)/driver/trips/[id]/page.tsx
@@ -1,0 +1,211 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { toast } from "sonner"
+import {
+  MapPin, Truck, Clock, ChevronLeft, ExternalLink,
+  ShieldAlert, FileText, Package
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+
+type TripDetail = {
+  id: string
+  status: string
+  origin: string
+  destination: string
+  scheduledAt: string | null
+  startedAt: string | null
+  deliveredAt: string | null
+  notes: string | null
+  truckName: string | null
+  truckPlate: string | null
+  truckType: string | null
+  loadName: string | null
+  loadHazardClass: string | null
+  loadUnNumber: string | null
+  loadHandlingNotes: string | null
+  loadRequiredCertifications: string[]
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  assigned: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  in_progress: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  delivered: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  cancelled: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  assigned: "Assigned",
+  in_progress: "In Progress",
+  delivered: "Delivered",
+  cancelled: "Cancelled",
+}
+
+const CERT_LABELS: Record<string, string> = {
+  hazmat: "HazMat Endorsement",
+  tanker: "Tanker Endorsement",
+  twic: "TWIC Card",
+  acid: "Acid/Corrosive Handling",
+  compressed_gas: "Compressed Gas",
+  explosives_precursor: "Explosives Precursor",
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  tanker: "Tanker",
+  hazmat: "HazMat Truck",
+  flatbed: "Flatbed",
+  refrigerated: "Refrigerated",
+}
+
+function formatDate(iso: string | null) {
+  if (!iso) return "—"
+  return new Date(iso).toLocaleString(undefined, {
+    weekday: "short", month: "short", day: "numeric",
+    hour: "2-digit", minute: "2-digit",
+  })
+}
+
+function mapsUrl(origin: string, destination: string) {
+  const q = encodeURIComponent(`${origin} to ${destination}`)
+  return `https://www.google.com/maps/dir/?api=1&origin=${encodeURIComponent(origin)}&destination=${encodeURIComponent(destination)}`
+}
+
+export default function TripDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const [trip, setTrip] = useState<TripDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch(`/api/driver/trips/${id}`)
+      .then((r) => {
+        if (!r.ok) throw new Error()
+        return r.json()
+      })
+      .then(setTrip)
+      .catch(() => {
+        toast.error("Trip not found")
+        router.push("/driver")
+      })
+      .finally(() => setLoading(false))
+  }, [id, router])
+
+  if (loading) {
+    return <div className="p-4 text-center text-muted-foreground pt-16">Loading...</div>
+  }
+
+  if (!trip) return null
+
+  return (
+    <div className="p-4 space-y-4 max-w-lg mx-auto">
+      {/* Back */}
+      <Button variant="ghost" size="sm" onClick={() => router.back()} className="-ml-2">
+        <ChevronLeft className="h-4 w-4 mr-1" /> Back
+      </Button>
+
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold">{trip.loadName ?? "Trip Detail"}</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">{trip.origin} → {trip.destination}</p>
+        </div>
+        <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold shrink-0 ${STATUS_STYLES[trip.status] ?? ""}`}>
+          {STATUS_LABELS[trip.status] ?? trip.status}
+        </span>
+      </div>
+
+      {/* Navigation button */}
+      <a
+        href={mapsUrl(trip.origin, trip.destination)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-center gap-2 w-full rounded-lg bg-primary text-primary-foreground py-3 text-sm font-semibold hover:bg-primary/90 transition-colors"
+      >
+        <MapPin className="h-4 w-4" />
+        Open in Google Maps
+        <ExternalLink className="h-3.5 w-3.5 opacity-70" />
+      </a>
+
+      {/* Route & Schedule */}
+      <section className="border rounded-xl divide-y">
+        <div className="p-4 flex items-start gap-3">
+          <MapPin className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-1 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Route</p>
+            <p><span className="text-muted-foreground">From</span> <span className="font-medium">{trip.origin}</span></p>
+            <p><span className="text-muted-foreground">To</span> <span className="font-medium">{trip.destination}</span></p>
+          </div>
+        </div>
+        <div className="p-4 flex items-start gap-3">
+          <Clock className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-1 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Schedule</p>
+            <p><span className="text-muted-foreground">Scheduled</span> <span className="font-medium">{formatDate(trip.scheduledAt)}</span></p>
+            {trip.startedAt && <p><span className="text-muted-foreground">Started</span> <span className="font-medium">{formatDate(trip.startedAt)}</span></p>}
+            {trip.deliveredAt && <p><span className="text-muted-foreground">Delivered</span> <span className="font-medium">{formatDate(trip.deliveredAt)}</span></p>}
+          </div>
+        </div>
+        {trip.truckName && (
+          <div className="p-4 flex items-start gap-3">
+            <Truck className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+            <div className="space-y-1 text-sm">
+              <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Vehicle</p>
+              <p className="font-medium">{trip.truckName}</p>
+              <p className="text-muted-foreground font-mono text-xs">{trip.truckPlate} · {TYPE_LABELS[trip.truckType ?? ""] ?? trip.truckType}</p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Chemical load details */}
+      <section className="border rounded-xl divide-y">
+        <div className="p-4 flex items-start gap-3">
+          <ShieldAlert className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-2 text-sm flex-1">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Chemical Load</p>
+            <p className="font-semibold">{trip.loadName}</p>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="outline">Class {trip.loadHazardClass}</Badge>
+              {trip.loadUnNumber && <Badge variant="outline">{trip.loadUnNumber}</Badge>}
+            </div>
+            {trip.loadRequiredCertifications?.length > 0 && (
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Required certifications:</p>
+                <div className="flex flex-wrap gap-1">
+                  {trip.loadRequiredCertifications.map((c) => (
+                    <Badge key={c} variant="secondary" className="text-xs">
+                      {CERT_LABELS[c] ?? c}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {trip.loadHandlingNotes && (
+          <div className="p-4 flex items-start gap-3">
+            <FileText className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+            <div className="space-y-1 text-sm">
+              <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Handling Notes</p>
+              <p className="text-sm leading-relaxed">{trip.loadHandlingNotes}</p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Trip notes */}
+      {trip.notes && (
+        <section className="border rounded-xl p-4 flex items-start gap-3">
+          <Package className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-1 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Dispatcher Notes</p>
+            <p className="leading-relaxed">{trip.notes}</p>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/driver/trips/[id]/route.ts
+++ b/src/app/api/driver/trips/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { trips, trucks, chemicalLoads, drivers } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { and, eq } from "drizzle-orm"
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { session } = await requireRole(["driver"])
+    const { id } = await params
+
+    // Verify this trip belongs to the current driver
+    const [driverProfile] = await db
+      .select()
+      .from(drivers)
+      .where(eq(drivers.userId, session.user.id))
+
+    if (!driverProfile) {
+      return NextResponse.json({ error: "No driver profile" }, { status: 403 })
+    }
+
+    const [trip] = await db
+      .select({
+        id: trips.id,
+        status: trips.status,
+        origin: trips.origin,
+        destination: trips.destination,
+        scheduledAt: trips.scheduledAt,
+        startedAt: trips.startedAt,
+        deliveredAt: trips.deliveredAt,
+        notes: trips.notes,
+        truckId: trips.truckId,
+        truckName: trucks.name,
+        truckPlate: trucks.plate,
+        truckType: trucks.type,
+        loadId: trips.loadId,
+        loadName: chemicalLoads.name,
+        loadHazardClass: chemicalLoads.hazardClass,
+        loadUnNumber: chemicalLoads.unNumber,
+        loadHandlingNotes: chemicalLoads.handlingNotes,
+        loadRequiredCertifications: chemicalLoads.requiredCertifications,
+      })
+      .from(trips)
+      .leftJoin(trucks, eq(trips.truckId, trucks.id))
+      .leftJoin(chemicalLoads, eq(trips.loadId, chemicalLoads.id))
+      .where(and(eq(trips.id, id), eq(trips.driverId, driverProfile.id)))
+
+    if (!trip) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(trip)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}


### PR DESCRIPTION
## Summary

Implements the driver-facing trip detail page.

### What's included
- **Trip detail API** — `GET /api/driver/trips/[id]` returns full trip info scoped to the authenticated driver (returns 404 if the trip doesn't belong to them)
- **Trip detail page** — `/driver/trips/[id]` shows:
  - Trip status badge
  - **Google Maps deep-link** — "Open in Google Maps" button pre-filled with origin → destination
  - Route section (origin, destination)
  - Schedule section (scheduled, started, delivered timestamps)
  - Vehicle section (truck name, plate, type)
  - Chemical load section (name, DOT hazard class badge, UN number, required certifications)
  - Handling notes section (from the chemical load definition)
  - Dispatcher notes section
  - Back navigation button

### Test plan
- [ ] Tapping a trip card on driver home navigates to `/driver/trips/[id]`
- [ ] All trip fields display correctly
- [ ] "Open in Google Maps" opens maps with correct origin/destination
- [ ] Handling notes and dispatcher notes show when present, hidden when empty
- [ ] Accessing another driver's trip returns to home with error toast
