### PR TITLE
feat: Driver Status Updates (Phase 3)

### DIFF
--- a/src/app/(driver)/driver/page.tsx
+++ b/src/app/(driver)/driver/page.tsx
@@ -3,9 +3,15 @@
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import Link from "next/link"
-import { MapPin, Package, CheckCircle, Clock, ChevronRight, Truck } from "lucide-react"
+import { MapPin, Package, CheckCircle, Clock, ChevronRight, Truck, Circle } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 type TripRow = {
   id: string
@@ -29,15 +35,23 @@ type HomeData = {
   stats: { completed: number; total: number }
 }
 
-const STATUS_STYLES: Record<string, string> = {
+const TRIP_STATUS_STYLES: Record<string, string> = {
   assigned: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
   in_progress: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
 }
 
-const STATUS_LABELS: Record<string, string> = {
+const TRIP_STATUS_LABELS: Record<string, string> = {
   assigned: "Assigned",
   in_progress: "In Progress",
 }
+
+const DRIVER_STATUS_OPTIONS = [
+  { value: "available", label: "Available", color: "text-green-600" },
+  { value: "on_shift", label: "On Shift", color: "text-blue-600" },
+  { value: "driving", label: "Driving", color: "text-purple-600" },
+  { value: "delivering", label: "Delivering", color: "text-orange-500" },
+  { value: "off_duty", label: "Off Duty", color: "text-gray-500" },
+]
 
 function formatDate(iso: string | null) {
   if (!iso) return "—"
@@ -50,6 +64,7 @@ function formatDate(iso: string | null) {
 export default function DriverHomePage() {
   const [data, setData] = useState<HomeData | null>(null)
   const [loading, setLoading] = useState(true)
+  const [updatingStatus, setUpdatingStatus] = useState(false)
 
   useEffect(() => {
     fetch("/api/driver/home")
@@ -58,6 +73,24 @@ export default function DriverHomePage() {
       .catch(() => toast.error("Failed to load your trips"))
       .finally(() => setLoading(false))
   }, [])
+
+  async function updateDriverStatus(status: string) {
+    setUpdatingStatus(true)
+    try {
+      const res = await fetch("/api/driver/status", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      })
+      if (!res.ok) throw new Error()
+      setData((prev) => prev ? { ...prev, driverProfile: prev.driverProfile ? { ...prev.driverProfile, status } : null } : prev)
+      toast.success(`Status updated to ${DRIVER_STATUS_OPTIONS.find((s) => s.value === status)?.label}`)
+    } catch {
+      toast.error("Failed to update status")
+    } finally {
+      setUpdatingStatus(false)
+    }
+  }
 
   if (loading) {
     return <div className="p-4 text-center text-muted-foreground pt-16">Loading...</div>
@@ -72,6 +105,34 @@ export default function DriverHomePage() {
         <h1 className="text-2xl font-bold">My Trips</h1>
         <p className="text-muted-foreground text-sm mt-0.5">Here&apos;s your day at a glance.</p>
       </div>
+
+      {/* Driver status selector */}
+      {driverProfile && (() => {
+        const current = DRIVER_STATUS_OPTIONS.find((s) => s.value === driverProfile.status)
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" disabled={updatingStatus} className="gap-2">
+                <Circle className={`h-2.5 w-2.5 fill-current ${current?.color ?? ""}`} />
+                {current?.label ?? driverProfile.status}
+                <span className="text-xs text-muted-foreground ml-1">· My Status</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              {DRIVER_STATUS_OPTIONS.map((opt) => (
+                <DropdownMenuItem
+                  key={opt.value}
+                  onClick={() => updateDriverStatus(opt.value)}
+                  className={`gap-2 ${opt.value === driverProfile.status ? "font-semibold" : ""}`}
+                >
+                  <Circle className={`h-2.5 w-2.5 fill-current ${opt.color}`} />
+                  {opt.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )
+      })()}
 
       {/* No driver profile */}
       {!driverProfile && (
@@ -95,8 +156,8 @@ export default function DriverHomePage() {
                     <Badge variant="outline" className="text-xs">Class {activeTrip.loadHazardClass}</Badge>
                   )}
                 </div>
-                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium shrink-0 ${STATUS_STYLES[activeTrip.status] ?? ""}`}>
-                  {STATUS_LABELS[activeTrip.status] ?? activeTrip.status}
+                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium shrink-0 ${TRIP_STATUS_STYLES[activeTrip.status] ?? ""}`}>
+                  {TRIP_STATUS_LABELS[activeTrip.status] ?? activeTrip.status}
                 </span>
               </div>
               <div className="flex items-center gap-2 text-sm">

--- a/src/app/(driver)/driver/trips/[id]/page.tsx
+++ b/src/app/(driver)/driver/trips/[id]/page.tsx
@@ -77,6 +77,7 @@ export default function TripDetailPage() {
   const router = useRouter()
   const [trip, setTrip] = useState<TripDetail | null>(null)
   const [loading, setLoading] = useState(true)
+  const [updating, setUpdating] = useState(false)
 
   useEffect(() => {
     fetch(`/api/driver/trips/${id}`)
@@ -91,6 +92,24 @@ export default function TripDetailPage() {
       })
       .finally(() => setLoading(false))
   }, [id, router])
+
+  async function updateTripStatus(status: "in_progress" | "delivered") {
+    setUpdating(true)
+    try {
+      const res = await fetch(`/api/driver/trips/${id}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      })
+      if (!res.ok) throw new Error()
+      setTrip((prev) => prev ? { ...prev, status, ...(status === "in_progress" ? { startedAt: new Date().toISOString() } : { deliveredAt: new Date().toISOString() }) } : prev)
+      toast.success(status === "in_progress" ? "Trip started!" : "Trip marked as delivered!")
+    } catch {
+      toast.error("Failed to update trip status")
+    } finally {
+      setUpdating(false)
+    }
+  }
 
   if (loading) {
     return <div className="p-4 text-center text-muted-foreground pt-16">Loading...</div>
@@ -127,6 +146,26 @@ export default function TripDetailPage() {
         Open in Google Maps
         <ExternalLink className="h-3.5 w-3.5 opacity-70" />
       </a>
+
+      {/* Trip action buttons */}
+      {trip.status === "assigned" && (
+        <Button
+          className="w-full"
+          onClick={() => updateTripStatus("in_progress")}
+          disabled={updating}
+        >
+          {updating ? "Updating..." : "Start Trip"}
+        </Button>
+      )}
+      {trip.status === "in_progress" && (
+        <Button
+          className="w-full"
+          onClick={() => updateTripStatus("delivered")}
+          disabled={updating}
+        >
+          {updating ? "Updating..." : "Mark as Delivered"}
+        </Button>
+      )}
 
       {/* Route & Schedule */}
       <section className="border rounded-xl divide-y">

--- a/src/app/api/driver/status/route.ts
+++ b/src/app/api/driver/status/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { drivers } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { eq } from "drizzle-orm"
+
+const statusSchema = z.object({
+  status: z.enum(["available", "on_shift", "driving", "delivering", "off_duty"]),
+})
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const { session } = await requireRole(["driver"])
+    const body = await req.json()
+    const { status } = statusSchema.parse(body)
+
+    const [updated] = await db
+      .update(drivers)
+      .set({ status })
+      .where(eq(drivers.userId, session.user.id))
+      .returning()
+
+    if (!updated) {
+      return NextResponse.json({ error: "No driver profile found" }, { status: 404 })
+    }
+
+    return NextResponse.json(updated)
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/driver/trips/[id]/status/route.ts
+++ b/src/app/api/driver/trips/[id]/status/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { trips, drivers } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+import { z } from "zod"
+import { and, eq } from "drizzle-orm"
+
+const statusSchema = z.object({
+  status: z.enum(["in_progress", "delivered"]),
+})
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { session } = await requireRole(["driver"])
+    const { id } = await params
+    const body = await req.json()
+    const { status } = statusSchema.parse(body)
+
+    const [driverProfile] = await db
+      .select()
+      .from(drivers)
+      .where(eq(drivers.userId, session.user.id))
+
+    if (!driverProfile) {
+      return NextResponse.json({ error: "No driver profile" }, { status: 403 })
+    }
+
+    const now = new Date()
+    const [updated] = await db
+      .update(trips)
+      .set({
+        status,
+        ...(status === "in_progress" ? { startedAt: now } : {}),
+        ...(status === "delivered" ? { deliveredAt: now } : {}),
+      })
+      .where(and(eq(trips.id, id), eq(trips.driverId, driverProfile.id)))
+      .returning()
+
+    if (!updated) {
+      return NextResponse.json({ error: "Trip not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(updated)
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}


### PR DESCRIPTION
## Summary

Implements driver status updates — both personal availability and trip lifecycle actions.

### What's included
- **Driver status API** — `PATCH /api/driver/status` lets drivers update their own availability (Available / On Shift / Driving / Delivering / Off Duty)
- **Trip status API** — `PATCH /api/driver/trips/[id]/status` lets drivers advance a trip they own (assigned → in_progress, in_progress → delivered). Sets `startedAt` / `deliveredAt` timestamps automatically
- **Driver home** — status dropdown in the header area showing current status with a colored dot. Selecting a new status updates immediately
- **Trip detail page** — contextual action buttons:
  - "Start Trip" shown when status is `assigned`
  - "Mark as Delivered" shown when status is `in_progress`
  - Both buttons update the UI optimistically and call the API

### Test plan
- [ ] Driver home shows current status with colored dot
- [ ] Selecting a new status from dropdown updates immediately
- [ ] Trip detail shows "Start Trip" for assigned trips
- [ ] Clicking "Start Trip" changes status to In Progress and shows started time
- [ ] Trip detail shows "Mark as Delivered" for in-progress trips
- [ ] Clicking "Mark as Delivered" changes status to Delivered
- [ ] Delivered trips show no action buttons
- [ ] Driver cannot update another driver's trip status
