### PR TITLE
feat: Trip Messaging — dispatcher ↔ driver chat (Phase 3)

### DIFF
--- a/drizzle/0004_bright_midnight.sql
+++ b/drizzle/0004_bright_midnight.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "messages" (
+	"id" text PRIMARY KEY NOT NULL,
+	"trip_id" text NOT NULL,
+	"sender_id" text NOT NULL,
+	"sender_name" text NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_trip_id_trips_id_fk" FOREIGN KEY ("trip_id") REFERENCES "public"."trips"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_sender_id_user_id_fk" FOREIGN KEY ("sender_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "messages_trip_id_idx" ON "messages" USING btree ("trip_id");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1073 @@
+{
+  "id": "28639eca-bb62-4911-9eea-23dee70492ff",
+  "prevId": "bce22afb-8b4e-4f54-be57-bfe6ff2cd361",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_account_idx": {
+          "name": "account_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chemical_loads": {
+      "name": "chemical_loads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hazard_class": {
+          "name": "hazard_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "un_number": {
+          "name": "un_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_vehicle_type": {
+          "name": "required_vehicle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_certifications": {
+          "name": "required_certifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "handling_notes": {
+          "name": "handling_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drivers": {
+      "name": "drivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certifications": {
+          "name": "certifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drivers_user_id_idx": {
+          "name": "drivers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drivers_user_id_user_id_fk": {
+          "name": "drivers_user_id_user_id_fk",
+          "tableFrom": "drivers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drivers_user_id_unique": {
+          "name": "drivers_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_idx": {
+          "name": "messages_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_user_id_fk": {
+          "name": "messages_sender_id_user_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_read_idx": {
+          "name": "notifications_read_idx",
+          "columns": [
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "truck_id": {
+          "name": "truck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driver_id": {
+          "name": "driver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "load_id": {
+          "name": "load_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_status_idx": {
+          "name": "trips_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trips_driver_id_idx": {
+          "name": "trips_driver_id_idx",
+          "columns": [
+            {
+              "expression": "driver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trips_truck_id_idx": {
+          "name": "trips_truck_id_idx",
+          "columns": [
+            {
+              "expression": "truck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_truck_id_trucks_id_fk": {
+          "name": "trips_truck_id_trucks_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "trucks",
+          "columnsFrom": [
+            "truck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trips_driver_id_drivers_id_fk": {
+          "name": "trips_driver_id_drivers_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trips_load_id_chemical_loads_id_fk": {
+          "name": "trips_load_id_chemical_loads_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "chemical_loads",
+          "columnsFrom": [
+            "load_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trips_created_by_user_id_fk": {
+          "name": "trips_created_by_user_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trucks": {
+      "name": "trucks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plate": {
+          "name": "plate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trucks_status_idx": {
+          "name": "trucks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trucks_plate_unique": {
+          "name": "trucks_plate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'driver'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1772767863386,
       "tag": "0003_kind_spyke",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772770953481,
+      "tag": "0004_bright_midnight",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dispatcher)/dispatch/trips/[id]/page.tsx
+++ b/src/app/(dispatcher)/dispatch/trips/[id]/page.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { MapPin, Truck, Clock, ChevronLeft, ShieldAlert, FileText, Users } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { TripMessageThread } from "@/components/trip-message-thread"
+
+type TripDetail = {
+  id: string
+  status: string
+  origin: string
+  destination: string
+  scheduledAt: string | null
+  startedAt: string | null
+  deliveredAt: string | null
+  notes: string | null
+  truckName: string | null
+  truckPlate: string | null
+  truckType: string | null
+  driverName: string | null
+  loadName: string | null
+  loadHazardClass: string | null
+  loadUnNumber: string | null
+  loadHandlingNotes: string | null
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  assigned: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  in_progress: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  delivered: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  cancelled: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: "Draft", assigned: "Assigned", in_progress: "In Progress",
+  delivered: "Delivered", cancelled: "Cancelled",
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  tanker: "Tanker", hazmat: "HazMat Truck", flatbed: "Flatbed", refrigerated: "Refrigerated",
+}
+
+function formatDate(iso: string | null) {
+  if (!iso) return "—"
+  return new Date(iso).toLocaleString(undefined, {
+    weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+  })
+}
+
+export default function DispatchTripDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const [trip, setTrip] = useState<TripDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [currentUserId, setCurrentUserId] = useState<string>("")
+
+  useEffect(() => {
+    fetch("/api/auth/get-session").then((r) => r.json()).then((s) => {
+      if (s?.user?.id) setCurrentUserId(s.user.id)
+    })
+  }, [])
+
+  useEffect(() => {
+    // Re-use the dispatch trips list API and find by id, or use a dedicated endpoint
+    fetch("/api/dispatch/trips")
+      .then((r) => r.json())
+      .then((rows: TripDetail[]) => {
+        const found = rows.find((t) => t.id === id)
+        if (!found) { toast.error("Trip not found"); router.push("/dispatch/trips") }
+        else setTrip(found)
+      })
+      .catch(() => { toast.error("Failed to load trip"); router.push("/dispatch/trips") })
+      .finally(() => setLoading(false))
+  }, [id, router])
+
+  if (loading) return <div className="p-6 text-center text-muted-foreground pt-16">Loading...</div>
+  if (!trip) return null
+
+  return (
+    <div className="p-6 space-y-4 max-w-2xl">
+      <Button variant="ghost" size="sm" onClick={() => router.back()} className="-ml-2">
+        <ChevronLeft className="h-4 w-4 mr-1" /> Back to Trips
+      </Button>
+
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold">{trip.loadName ?? "Trip Detail"}</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">{trip.origin} → {trip.destination}</p>
+        </div>
+        <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold shrink-0 ${STATUS_STYLES[trip.status] ?? ""}`}>
+          {STATUS_LABELS[trip.status] ?? trip.status}
+        </span>
+      </div>
+
+      {/* Details */}
+      <section className="border rounded-xl divide-y">
+        <div className="p-4 flex items-start gap-3">
+          <MapPin className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-1 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Route</p>
+            <p><span className="text-muted-foreground">From</span> <span className="font-medium">{trip.origin}</span></p>
+            <p><span className="text-muted-foreground">To</span> <span className="font-medium">{trip.destination}</span></p>
+          </div>
+        </div>
+        <div className="p-4 flex items-start gap-3">
+          <Clock className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-1 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Schedule</p>
+            <p><span className="text-muted-foreground">Scheduled</span> <span className="font-medium">{formatDate(trip.scheduledAt)}</span></p>
+            {trip.startedAt && <p><span className="text-muted-foreground">Started</span> <span className="font-medium">{formatDate(trip.startedAt)}</span></p>}
+            {trip.deliveredAt && <p><span className="text-muted-foreground">Delivered</span> <span className="font-medium">{formatDate(trip.deliveredAt)}</span></p>}
+          </div>
+        </div>
+        <div className="p-4 flex items-start gap-3">
+          <Truck className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-1 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Vehicle</p>
+            <p className="font-medium">{trip.truckName ?? "—"}</p>
+            {trip.truckPlate && <p className="text-muted-foreground font-mono text-xs">{trip.truckPlate} · {TYPE_LABELS[trip.truckType ?? ""] ?? trip.truckType}</p>}
+          </div>
+        </div>
+        <div className="p-4 flex items-start gap-3">
+          <Users className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-1 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Driver</p>
+            <p className="font-medium">{trip.driverName ?? "—"}</p>
+          </div>
+        </div>
+        <div className="p-4 flex items-start gap-3">
+          <ShieldAlert className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+          <div className="space-y-2 text-sm">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Chemical Load</p>
+            <div className="flex flex-wrap gap-2">
+              {trip.loadHazardClass && <Badge variant="outline">Class {trip.loadHazardClass}</Badge>}
+              {trip.loadUnNumber && <Badge variant="outline">{trip.loadUnNumber}</Badge>}
+            </div>
+          </div>
+        </div>
+        {trip.loadHandlingNotes && (
+          <div className="p-4 flex items-start gap-3">
+            <FileText className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+            <div className="space-y-1 text-sm">
+              <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Handling Notes</p>
+              <p className="leading-relaxed">{trip.loadHandlingNotes}</p>
+            </div>
+          </div>
+        )}
+        {trip.notes && (
+          <div className="p-4 flex items-start gap-3">
+            <FileText className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+            <div className="space-y-1 text-sm">
+              <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Dispatcher Notes</p>
+              <p className="leading-relaxed">{trip.notes}</p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Messages */}
+      {currentUserId && <TripMessageThread tripId={trip.id} currentUserId={currentUserId} />}
+    </div>
+  )
+}

--- a/src/app/(dispatcher)/dispatch/trips/page.tsx
+++ b/src/app/(dispatcher)/dispatch/trips/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
-import { Plus, MapPin, ChevronDown } from "lucide-react"
+import Link from "next/link"
+import { Plus, MapPin, ChevronDown, MessageSquare } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -209,6 +210,12 @@ export default function TripsPage() {
                     </span>
                   </TableCell>
                   <TableCell>
+                    <div className="flex items-center gap-1">
+                    <Button size="icon" variant="ghost" asChild title="Messages">
+                      <Link href={`/dispatch/trips/${trip.id}`}>
+                        <MessageSquare className="h-4 w-4" />
+                      </Link>
+                    </Button>
                     {NEXT_STATUSES[trip.status] ? (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
@@ -234,6 +241,7 @@ export default function TripsPage() {
                     ) : (
                       <span className="text-xs text-muted-foreground">—</span>
                     )}
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/src/app/(driver)/driver/trips/[id]/page.tsx
+++ b/src/app/(driver)/driver/trips/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { TripMessageThread } from "@/components/trip-message-thread"
 
 type TripDetail = {
   id: string
@@ -77,6 +78,13 @@ export default function TripDetailPage() {
   const router = useRouter()
   const [trip, setTrip] = useState<TripDetail | null>(null)
   const [loading, setLoading] = useState(true)
+  const [currentUserId, setCurrentUserId] = useState<string>("")
+
+  useEffect(() => {
+    fetch("/api/auth/get-session").then((r) => r.json()).then((s) => {
+      if (s?.user?.id) setCurrentUserId(s.user.id)
+    })
+  }, [])
   const [updating, setUpdating] = useState(false)
 
   useEffect(() => {
@@ -245,6 +253,9 @@ export default function TripDetailPage() {
           </div>
         </section>
       )}
+
+      {/* Messages */}
+      {currentUserId && <TripMessageThread tripId={trip.id} currentUserId={currentUserId} />}
     </div>
   )
 }

--- a/src/app/api/trips/[id]/messages/route.ts
+++ b/src/app/api/trips/[id]/messages/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { messages, trips, drivers } from "@/lib/schema"
+import { requireAuth } from "@/lib/session"
+import { z } from "zod"
+import { and, asc, eq } from "drizzle-orm"
+
+const messageSchema = z.object({
+  content: z.string().min(1, "Message cannot be empty").max(1000),
+})
+
+async function canAccessTrip(tripId: string, userId: string, role: string) {
+  if (role === "admin" || role === "dispatcher") return true
+  if (role === "driver") {
+    const [driverProfile] = await db.select().from(drivers).where(eq(drivers.userId, userId))
+    if (!driverProfile) return false
+    const [trip] = await db.select({ id: trips.id }).from(trips)
+      .where(and(eq(trips.id, tripId), eq(trips.driverId, driverProfile.id)))
+    return !!trip
+  }
+  return false
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth()
+    const { id } = await params
+    const role = (session.user as { role?: string }).role ?? ""
+
+    if (!await canAccessTrip(id, session.user.id, role)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    const rows = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.tripId, id))
+      .orderBy(asc(messages.createdAt))
+
+    return NextResponse.json(rows)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth()
+    const { id } = await params
+    const role = (session.user as { role?: string }).role ?? ""
+
+    if (!await canAccessTrip(id, session.user.id, role)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    const body = await req.json()
+    const { content } = messageSchema.parse(body)
+
+    const [message] = await db.insert(messages).values({
+      tripId: id,
+      senderId: session.user.id,
+      senderName: session.user.name,
+      content,
+    }).returning()
+
+    return NextResponse.json(message, { status: 201 })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.errors[0].message }, { status: 400 })
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/components/trip-message-thread.tsx
+++ b/src/components/trip-message-thread.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useEffect, useRef, useState, useCallback } from "react"
+import { toast } from "sonner"
+import { Send, MessageSquare } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+
+type Message = {
+  id: string
+  senderId: string
+  senderName: string
+  content: string
+  createdAt: string
+}
+
+function timeAgo(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return "just now"
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}
+
+interface Props {
+  tripId: string
+  currentUserId: string
+}
+
+export function TripMessageThread({ tripId, currentUserId }: Props) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [content, setContent] = useState("")
+  const [sending, setSending] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const fetchMessages = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/trips/${tripId}/messages`)
+      if (res.ok) {
+        const data = await res.json()
+        setMessages(data)
+      }
+    } catch {
+      // silently ignore poll failures
+    }
+  }, [tripId])
+
+  useEffect(() => {
+    fetchMessages()
+    const interval = setInterval(fetchMessages, 10000)
+    return () => clearInterval(interval)
+  }, [fetchMessages])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages])
+
+  async function sendMessage() {
+    if (!content.trim()) return
+    setSending(true)
+    try {
+      const res = await fetch(`/api/trips/${tripId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: content.trim() }),
+      })
+      if (!res.ok) throw new Error()
+      const msg = await res.json()
+      setMessages((prev) => [...prev, msg])
+      setContent("")
+    } catch {
+      toast.error("Failed to send message")
+    } finally {
+      setSending(false)
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
+  }
+
+  return (
+    <section className="border rounded-xl overflow-hidden">
+      <div className="p-3 border-b flex items-center gap-2 text-sm font-medium">
+        <MessageSquare className="h-4 w-4 text-muted-foreground" />
+        Messages
+      </div>
+
+      {/* Message list */}
+      <div className="p-3 space-y-3 max-h-64 overflow-y-auto bg-muted/20">
+        {messages.length === 0 ? (
+          <p className="text-xs text-center text-muted-foreground py-4">
+            No messages yet. Start the conversation.
+          </p>
+        ) : (
+          messages.map((msg) => {
+            const isOwn = msg.senderId === currentUserId
+            return (
+              <div key={msg.id} className={`flex flex-col ${isOwn ? "items-end" : "items-start"}`}>
+                <div className={`max-w-[80%] rounded-2xl px-3 py-2 text-sm ${isOwn ? "bg-primary text-primary-foreground rounded-br-sm" : "bg-background border rounded-bl-sm"}`}>
+                  {msg.content}
+                </div>
+                <p className="text-[10px] text-muted-foreground mt-0.5 px-1">
+                  {!isOwn && <span className="font-medium">{msg.senderName} · </span>}
+                  {timeAgo(msg.createdAt)}
+                </p>
+              </div>
+            )
+          })
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div className="p-3 border-t flex gap-2">
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a message… (Enter to send)"
+          rows={1}
+          className="resize-none text-sm"
+          disabled={sending}
+        />
+        <Button size="icon" onClick={sendMessage} disabled={sending || !content.trim()}>
+          <Send className="h-4 w-4" />
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -178,6 +178,23 @@ export const trips = pgTable(
   ]
 );
 
+export const messages = pgTable(
+  "messages",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    tripId: text("trip_id")
+      .notNull()
+      .references(() => trips.id, { onDelete: "cascade" }),
+    senderId: text("sender_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    senderName: text("sender_name").notNull(),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [index("messages_trip_id_idx").on(table.tripId)]
+)
+
 export const notifications = pgTable(
   "notifications",
   {
@@ -205,6 +222,7 @@ export type Driver = typeof drivers.$inferSelect;
 export type ChemicalLoad = typeof chemicalLoads.$inferSelect;
 export type Trip = typeof trips.$inferSelect;
 
+export type Message = typeof messages.$inferSelect;
 export type Notification = typeof notifications.$inferSelect;
 export type UserRole = "admin" | "dispatcher" | "driver";
 export type TruckStatus = "available" | "on_trip" | "maintenance" | "inactive";


### PR DESCRIPTION
## Summary

Implements per-trip messaging between dispatchers and drivers.

### What's included
- **Schema** — new `messages` table (tripId, senderId, senderName, content, createdAt) with migration
- **Messages API** — `GET /api/trips/[id]/messages` and `POST /api/trips/[id]/messages`. Access controlled: dispatchers/admins can access any trip; drivers can only access trips assigned to them
- **Reusable `TripMessageThread` component** — chat bubble UI, polls every 10 seconds, Enter to send, auto-scrolls to latest message
- **Driver trip detail** — message thread added at the bottom of `/driver/trips/[id]`
- **Dispatcher trip detail** — new page at `/dispatch/trips/[id]` with full trip info + message thread
- **Dispatcher trips list** — chat icon button on each row links to the trip detail/messages page

### Test plan
- [ ] Run `pnpm db:migrate` to create the messages table
- [ ] Dispatcher opens a trip detail via the chat icon → message thread visible
- [ ] Dispatcher sends a message → appears in thread
- [ ] Driver opens same trip → sees the dispatcher's message
- [ ] Driver replies → dispatcher sees it (within 10s poll)
- [ ] Messages from self appear on the right (blue), others on the left
- [ ] Driver cannot access messages for trips not assigned to them
