### PR TITLE
feat: driver GPS location capture

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["192.168.0.14"],
+  allowedDevOrigins: ["192.168.0.14", "5e8e-73-182-153-238.ngrok-free.app"],
   // Image optimization configuration
   images: {
     remotePatterns: [
@@ -47,7 +47,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: "Permissions-Policy",
-            value: "camera=(), microphone=(), geolocation=()",
+            value: "camera=(), microphone=()",
           },
         ],
       },

--- a/src/components/gps-tracker.tsx
+++ b/src/components/gps-tracker.tsx
@@ -57,7 +57,7 @@ export function GpsTracker({ active }: Props) {
     }
   }, [active])
 
-  if (!active || status === "idle") return null
+  if (!active) return null
 
   return (
     <div className="fixed bottom-20 right-3 z-50">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,6 +8,7 @@ export const auth = betterAuth({
   baseURL,
   trustedOrigins: [
     "http://localhost:3000",
+    "https://5e8e-73-182-153-238.ngrok-free.app",
     baseURL,
   ],
   database: drizzleAdapter(db, {


### PR DESCRIPTION
## Summary

- Adds `truck_locations` table (truckId, driverId, lat, lng, heading, speed, recordedAt)
- `POST /api/driver/location` — captures GPS from driver's device, resolves active trip's truck, and inserts a location record
- `GpsTracker` component on the driver trip detail page — sends location immediately on mount, then every 30 s; shows green pill when tracking, red pill on denial/error
- Fixes `Permissions-Policy` header that was blocking the Geolocation API
- Adds ngrok and local-IP origins to BetterAuth `trustedOrigins` for mobile testing

## Test plan
- [ ] Run `pnpm db:migrate` to create the `truck_locations` table
- [ ] Open a trip detail page as a driver with an active trip (via ngrok HTTPS URL on mobile)
- [ ] Allow location permission — green "Sharing location" pill appears
- [ ] Check `pnpm db:studio` → `truck_locations` shows new rows every 30 s
- [ ] Deny location → red "Location denied" pill appears
- [ ] Deliver the trip → pill disappears