### PR TITLE
Hours of Service (HOS) logging — Phase 5 #21

### DIFF
--- a/drizzle/0008_quick_tusk.sql
+++ b/drizzle/0008_quick_tusk.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "hos_logs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"driver_id" text NOT NULL,
+	"trip_id" text,
+	"type" text NOT NULL,
+	"shift_start" timestamp,
+	"shift_end" timestamp,
+	"driving_minutes" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "hos_logs" ADD CONSTRAINT "hos_logs_driver_id_drivers_id_fk" FOREIGN KEY ("driver_id") REFERENCES "public"."drivers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "hos_logs" ADD CONSTRAINT "hos_logs_trip_id_trips_id_fk" FOREIGN KEY ("trip_id") REFERENCES "public"."trips"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "hos_logs_driver_id_idx" ON "hos_logs" USING btree ("driver_id");--> statement-breakpoint
+CREATE INDEX "hos_logs_created_at_idx" ON "hos_logs" USING btree ("created_at");

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1529 @@
+{
+  "id": "41574d48-bad5-43d4-a28e-22d03490d873",
+  "prevId": "42b52c44-6043-45a2-b484-4a17bcec739a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_account_idx": {
+          "name": "account_provider_account_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chemical_loads": {
+      "name": "chemical_loads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hazard_class": {
+          "name": "hazard_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "un_number": {
+          "name": "un_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_vehicle_type": {
+          "name": "required_vehicle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_certifications": {
+          "name": "required_certifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "handling_notes": {
+          "name": "handling_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drivers": {
+      "name": "drivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certifications": {
+          "name": "certifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drivers_user_id_idx": {
+          "name": "drivers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drivers_user_id_user_id_fk": {
+          "name": "drivers_user_id_user_id_fk",
+          "tableFrom": "drivers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drivers_user_id_unique": {
+          "name": "drivers_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hos_logs": {
+      "name": "hos_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driver_id": {
+          "name": "driver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_start": {
+          "name": "shift_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shift_end": {
+          "name": "shift_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driving_minutes": {
+          "name": "driving_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hos_logs_driver_id_idx": {
+          "name": "hos_logs_driver_id_idx",
+          "columns": [
+            {
+              "expression": "driver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hos_logs_created_at_idx": {
+          "name": "hos_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hos_logs_driver_id_drivers_id_fk": {
+          "name": "hos_logs_driver_id_drivers_id_fk",
+          "tableFrom": "hos_logs",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hos_logs_trip_id_trips_id_fk": {
+          "name": "hos_logs_trip_id_trips_id_fk",
+          "tableFrom": "hos_logs",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_idx": {
+          "name": "messages_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_user_id_fk": {
+          "name": "messages_sender_id_user_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_read_idx": {
+          "name": "notifications_read_idx",
+          "columns": [
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proof_of_deliveries": {
+      "name": "proof_of_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_id": {
+          "name": "driver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_data_url": {
+          "name": "signature_data_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pod_trip_id_idx": {
+          "name": "pod_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proof_of_deliveries_trip_id_trips_id_fk": {
+          "name": "proof_of_deliveries_trip_id_trips_id_fk",
+          "tableFrom": "proof_of_deliveries",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proof_of_deliveries_driver_id_drivers_id_fk": {
+          "name": "proof_of_deliveries_driver_id_drivers_id_fk",
+          "tableFrom": "proof_of_deliveries",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "proof_of_deliveries_trip_id_unique": {
+          "name": "proof_of_deliveries_trip_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_inspections": {
+      "name": "trip_inspections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_id": {
+          "name": "driver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items": {
+          "name": "items",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_inspections_trip_id_idx": {
+          "name": "trip_inspections_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trip_inspections_type_idx": {
+          "name": "trip_inspections_type_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_inspections_trip_id_trips_id_fk": {
+          "name": "trip_inspections_trip_id_trips_id_fk",
+          "tableFrom": "trip_inspections",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_inspections_driver_id_drivers_id_fk": {
+          "name": "trip_inspections_driver_id_drivers_id_fk",
+          "tableFrom": "trip_inspections",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "truck_id": {
+          "name": "truck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driver_id": {
+          "name": "driver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "load_id": {
+          "name": "load_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_status_idx": {
+          "name": "trips_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trips_driver_id_idx": {
+          "name": "trips_driver_id_idx",
+          "columns": [
+            {
+              "expression": "driver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trips_truck_id_idx": {
+          "name": "trips_truck_id_idx",
+          "columns": [
+            {
+              "expression": "truck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_truck_id_trucks_id_fk": {
+          "name": "trips_truck_id_trucks_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "trucks",
+          "columnsFrom": [
+            "truck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trips_driver_id_drivers_id_fk": {
+          "name": "trips_driver_id_drivers_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trips_load_id_chemical_loads_id_fk": {
+          "name": "trips_load_id_chemical_loads_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "chemical_loads",
+          "columnsFrom": [
+            "load_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trips_created_by_user_id_fk": {
+          "name": "trips_created_by_user_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.truck_locations": {
+      "name": "truck_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "truck_id": {
+          "name": "truck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_id": {
+          "name": "driver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "truck_locations_truck_id_idx": {
+          "name": "truck_locations_truck_id_idx",
+          "columns": [
+            {
+              "expression": "truck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "truck_locations_recorded_at_idx": {
+          "name": "truck_locations_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "truck_locations_truck_id_trucks_id_fk": {
+          "name": "truck_locations_truck_id_trucks_id_fk",
+          "tableFrom": "truck_locations",
+          "tableTo": "trucks",
+          "columnsFrom": [
+            "truck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "truck_locations_driver_id_drivers_id_fk": {
+          "name": "truck_locations_driver_id_drivers_id_fk",
+          "tableFrom": "truck_locations",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trucks": {
+      "name": "trucks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plate": {
+          "name": "plate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trucks_status_idx": {
+          "name": "trucks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trucks_plate_unique": {
+          "name": "trucks_plate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'driver'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1772860072665,
       "tag": "0007_spicy_iron_patriot",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1772910138468,
+      "tag": "0008_quick_tusk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dispatcher)/dispatch/hos/page.tsx
+++ b/src/app/(dispatcher)/dispatch/hos/page.tsx
@@ -1,0 +1,179 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { AlertTriangle, CheckCircle, ChevronLeft, Clock, Timer, Users } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+
+type DriverHos = {
+  driverId: string
+  driverName: string
+  driverEmail: string
+  driverStatus: string
+  licenseNumber: string
+  drivingHours: number
+  onDutyHours: number
+  isOnShift: boolean
+  flags: string[]
+}
+
+const DRIVER_STATUS_LABELS: Record<string, string> = {
+  available: "Available",
+  on_shift: "On Shift",
+  driving: "Driving",
+  delivering: "Delivering",
+  off_duty: "Off Duty",
+}
+
+const DRIVER_STATUS_COLORS: Record<string, string> = {
+  available: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  on_shift: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  driving: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  delivering: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+  off_duty: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+}
+
+function HosBar({ value, max, warn, danger }: { value: number; max: number; warn: number; danger: number }) {
+  const pct = Math.min((value / max) * 100, 100)
+  const color = value >= danger ? "bg-red-500" : value >= warn ? "bg-orange-400" : "bg-green-500"
+  return (
+    <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
+      <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${pct}%` }} />
+    </div>
+  )
+}
+
+export default function HosCompliancePage() {
+  const router = useRouter()
+  const [drivers, setDrivers] = useState<DriverHos[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch("/api/dispatch/hos")
+      .then((r) => r.json())
+      .then((data) => { if (Array.isArray(data)) setDrivers(data) })
+      .catch(() => toast.error("Failed to load HOS data"))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const flagged = drivers.filter((d) => d.flags.length > 0)
+  const clean = drivers.filter((d) => d.flags.length === 0)
+
+  return (
+    <div className="p-6 space-y-6 max-w-4xl">
+      <Button variant="ghost" size="sm" onClick={() => router.back()} className="-ml-2">
+        <ChevronLeft className="h-4 w-4 mr-1" /> Back
+      </Button>
+
+      <div>
+        <h1 className="text-2xl font-bold">HOS Compliance</h1>
+        <p className="text-muted-foreground text-sm mt-1">Hours of service — 7-day rolling window. Limits: 11h driving / 14h on-duty.</p>
+      </div>
+
+      {loading ? (
+        <div className="border rounded-xl p-10 text-center text-muted-foreground text-sm">Loading...</div>
+      ) : drivers.length === 0 ? (
+        <div className="border rounded-xl p-10 text-center text-muted-foreground text-sm">
+          <Users className="h-8 w-8 mx-auto mb-2 opacity-30" />
+          No driver profiles found.
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {/* Flagged drivers */}
+          {flagged.length > 0 && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-orange-500" />
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Needs Attention ({flagged.length})
+                </h2>
+              </div>
+              <div className="space-y-2">
+                {flagged.map((d) => (
+                  <DriverHosCard key={d.driverId} driver={d} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* All-clear drivers */}
+          {clean.length > 0 && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <CheckCircle className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Within Limits ({clean.length})
+                </h2>
+              </div>
+              <div className="space-y-2">
+                {clean.map((d) => (
+                  <DriverHosCard key={d.driverId} driver={d} />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DriverHosCard({ driver }: { driver: DriverHos }) {
+  const hasCritical = driver.flags.some((f) => f.includes("exceeded"))
+  return (
+    <div className={`border rounded-xl p-4 space-y-3 ${hasCritical ? "border-red-300 dark:border-red-800" : driver.flags.length > 0 ? "border-orange-300 dark:border-orange-800" : ""}`}>
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <p className="font-semibold text-sm">{driver.driverName}</p>
+          <p className="text-xs text-muted-foreground">{driver.licenseNumber}</p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${DRIVER_STATUS_COLORS[driver.driverStatus] ?? ""}`}>
+            {DRIVER_STATUS_LABELS[driver.driverStatus] ?? driver.driverStatus}
+          </span>
+          {driver.isOnShift && (
+            <Badge variant="outline" className="text-xs">On shift</Badge>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-1 text-muted-foreground"><Timer className="h-3 w-3" /> Driving</span>
+            <span className={`font-medium ${driver.drivingHours >= 11 ? "text-red-600" : driver.drivingHours >= 10 ? "text-orange-500" : ""}`}>
+              {driver.drivingHours}h / 11h
+            </span>
+          </div>
+          <HosBar value={driver.drivingHours} max={11} warn={10} danger={11} />
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-1 text-muted-foreground"><Clock className="h-3 w-3" /> On-Duty</span>
+            <span className={`font-medium ${driver.onDutyHours >= 14 ? "text-red-600" : driver.onDutyHours >= 13 ? "text-orange-500" : ""}`}>
+              {driver.onDutyHours}h / 14h
+            </span>
+          </div>
+          <HosBar value={driver.onDutyHours} max={14} warn={13} danger={14} />
+        </div>
+      </div>
+
+      {driver.flags.length > 0 && (
+        <div className="space-y-1">
+          {driver.flags.map((flag) => (
+            <div key={flag} className={`flex items-center gap-2 text-xs rounded-lg px-3 py-1.5 ${
+              flag.includes("exceeded")
+                ? "bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400"
+                : "bg-orange-50 text-orange-700 dark:bg-orange-900/20 dark:text-orange-400"
+            }`}>
+              <AlertTriangle className="h-3 w-3 shrink-0" />
+              {flag}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(driver)/driver/page.tsx
+++ b/src/app/(driver)/driver/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { MapPin, Package, CheckCircle, Clock, ChevronRight, Truck, Circle } from "lucide-react"
+import { MapPin, Package, CheckCircle, Clock, ChevronRight, Truck, Circle, AlertTriangle, Timer } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -36,6 +36,18 @@ type HomeData = {
   stats: { completed: number; total: number }
 }
 
+type HosSummary = {
+  drivingHours: number
+  onDutyHours: number
+  isOnShift: boolean
+  warnings: {
+    approachingDrivingLimit: boolean
+    exceededDrivingLimit: boolean
+    approachingOnDutyLimit: boolean
+    exceededOnDutyLimit: boolean
+  }
+}
+
 const TRIP_STATUS_STYLES: Record<string, string> = {
   assigned: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
   in_progress: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
@@ -65,6 +77,7 @@ function formatDate(iso: string | null) {
 export default function DriverHomePage() {
   const router = useRouter()
   const [data, setData] = useState<HomeData | null>(null)
+  const [hos, setHos] = useState<HosSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [updatingStatus, setUpdatingStatus] = useState(false)
 
@@ -74,6 +87,11 @@ export default function DriverHomePage() {
       .then(setData)
       .catch(() => toast.error("Failed to load your trips"))
       .finally(() => setLoading(false))
+
+    fetch("/api/driver/hos")
+      .then((r) => r.json())
+      .then((d) => { if (d && !d.error) setHos(d) })
+      .catch(() => {})
   }, [])
 
   async function updateDriverStatus(status: string) {
@@ -219,6 +237,52 @@ export default function DriverHomePage() {
               <span>Completed</span>
             </div>
             <p className="text-2xl font-bold">{stats?.completed ?? 0}</p>
+          </div>
+        </div>
+      )}
+
+      {/* HOS summary */}
+      {driverProfile && hos && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Hours of Service (7-day)</h2>
+          <div className="border rounded-xl p-4 space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Timer className="h-3.5 w-3.5" />
+                  Driving
+                </div>
+                <p className={`text-xl font-bold ${hos.warnings.exceededDrivingLimit ? "text-red-600" : hos.warnings.approachingDrivingLimit ? "text-orange-500" : ""}`}>
+                  {hos.drivingHours}h <span className="text-sm font-normal text-muted-foreground">/ 11h</span>
+                </p>
+              </div>
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Clock className="h-3.5 w-3.5" />
+                  On-Duty
+                </div>
+                <p className={`text-xl font-bold ${hos.warnings.exceededOnDutyLimit ? "text-red-600" : hos.warnings.approachingOnDutyLimit ? "text-orange-500" : ""}`}>
+                  {hos.onDutyHours}h <span className="text-sm font-normal text-muted-foreground">/ 14h</span>
+                </p>
+              </div>
+            </div>
+            {(hos.warnings.approachingDrivingLimit || hos.warnings.exceededDrivingLimit ||
+              hos.warnings.approachingOnDutyLimit || hos.warnings.exceededOnDutyLimit) && (
+              <div className={`flex items-center gap-2 text-xs rounded-lg px-3 py-2 ${
+                hos.warnings.exceededDrivingLimit || hos.warnings.exceededOnDutyLimit
+                  ? "bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400"
+                  : "bg-orange-50 text-orange-700 dark:bg-orange-900/20 dark:text-orange-400"
+              }`}>
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                {hos.warnings.exceededDrivingLimit
+                  ? "Driving limit exceeded — rest required"
+                  : hos.warnings.exceededOnDutyLimit
+                  ? "On-duty limit exceeded — rest required"
+                  : hos.warnings.approachingDrivingLimit
+                  ? "Approaching 11h driving limit"
+                  : "Approaching 14h on-duty limit"}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/app/api/dispatch/hos/route.ts
+++ b/src/app/api/dispatch/hos/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server"
+import { eq, gte } from "drizzle-orm"
+import { db } from "@/lib/db"
+import { drivers, hosLogs, user } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+
+const MAX_DRIVING_HOURS = 11
+const MAX_ONDUTY_HOURS = 14
+const WARN_DRIVING_HOURS = 10
+const WARN_ONDUTY_HOURS = 13
+
+export async function GET() {
+  try {
+    await requireRole(["dispatcher", "admin"])
+
+    const since = new Date()
+    since.setDate(since.getDate() - 7)
+    const now = new Date()
+
+    const allDrivers = await db
+      .select({
+        id: drivers.id,
+        status: drivers.status,
+        licenseNumber: drivers.licenseNumber,
+        userName: user.name,
+        userEmail: user.email,
+      })
+      .from(drivers)
+      .leftJoin(user, eq(drivers.userId, user.id))
+
+    const allLogs = await db
+      .select()
+      .from(hosLogs)
+      .where(gte(hosLogs.createdAt, since))
+
+    const result = allDrivers.map((driver) => {
+      const logs = allLogs.filter((l) => l.driverId === driver.id)
+
+      const weeklyDrivingMinutes = logs
+        .filter((l) => l.type === "driving")
+        .reduce((sum, l) => sum + l.drivingMinutes, 0)
+
+      const weeklyOnDutyMinutes = logs
+        .filter((l) => l.type === "shift" && l.shiftEnd !== null)
+        .reduce((sum, l) => {
+          const start = l.shiftStart ? new Date(l.shiftStart).getTime() : 0
+          const end = l.shiftEnd ? new Date(l.shiftEnd).getTime() : now.getTime()
+          return sum + Math.round((end - start) / 60000)
+        }, 0)
+
+      const openShift = logs.find((l) => l.type === "shift" && l.shiftEnd === null)
+      const currentShiftMinutes = openShift?.shiftStart
+        ? Math.round((now.getTime() - new Date(openShift.shiftStart).getTime()) / 60000)
+        : 0
+
+      const drivingHours = +(weeklyDrivingMinutes / 60).toFixed(1)
+      const onDutyHours = +((weeklyOnDutyMinutes + currentShiftMinutes) / 60).toFixed(1)
+
+      const flags: string[] = []
+      if (drivingHours >= MAX_DRIVING_HOURS) flags.push("Driving limit exceeded")
+      else if (drivingHours >= WARN_DRIVING_HOURS) flags.push("Approaching driving limit")
+      if (onDutyHours >= MAX_ONDUTY_HOURS) flags.push("On-duty limit exceeded")
+      else if (onDutyHours >= WARN_ONDUTY_HOURS) flags.push("Approaching on-duty limit")
+
+      return {
+        driverId: driver.id,
+        driverName: driver.userName ?? "Unknown",
+        driverEmail: driver.userEmail ?? "",
+        driverStatus: driver.status,
+        licenseNumber: driver.licenseNumber,
+        drivingHours,
+        onDutyHours,
+        isOnShift: !!openShift,
+        flags,
+      }
+    })
+
+    return NextResponse.json(result)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/driver/hos/route.ts
+++ b/src/app/api/driver/hos/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server"
+import { and, eq, gte } from "drizzle-orm"
+import { db } from "@/lib/db"
+import { drivers, hosLogs } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+
+// HOS federal limits
+const MAX_DRIVING_HOURS = 11
+const MAX_ONDUTY_HOURS = 14
+const WARN_DRIVING_HOURS = 10
+const WARN_ONDUTY_HOURS = 13
+
+export async function GET() {
+  try {
+    const { session } = await requireRole(["driver"])
+
+    const [driver] = await db
+      .select({ id: drivers.id })
+      .from(drivers)
+      .where(eq(drivers.userId, session.user.id))
+      .limit(1)
+
+    if (!driver) return NextResponse.json({ error: "No driver profile" }, { status: 404 })
+
+    // Last 7 days
+    const since = new Date()
+    since.setDate(since.getDate() - 7)
+
+    const logs = await db
+      .select()
+      .from(hosLogs)
+      .where(and(eq(hosLogs.driverId, driver.id), gte(hosLogs.createdAt, since)))
+
+    const now = new Date()
+
+    // Weekly driving minutes from completed driving records
+    const weeklyDrivingMinutes = logs
+      .filter((l) => l.type === "driving")
+      .reduce((sum, l) => sum + l.drivingMinutes, 0)
+
+    // Weekly on-duty minutes from completed shifts
+    const weeklyOnDutyMinutes = logs
+      .filter((l) => l.type === "shift" && l.shiftEnd !== null)
+      .reduce((sum, l) => {
+        const start = l.shiftStart ? new Date(l.shiftStart).getTime() : 0
+        const end = l.shiftEnd ? new Date(l.shiftEnd).getTime() : now.getTime()
+        return sum + Math.round((end - start) / 60000)
+      }, 0)
+
+    // Open shift (if currently on duty)
+    const openShift = logs.find((l) => l.type === "shift" && l.shiftEnd === null)
+    const currentShiftMinutes = openShift?.shiftStart
+      ? Math.round((now.getTime() - new Date(openShift.shiftStart).getTime()) / 60000)
+      : 0
+
+    const totalOnDutyMinutes = weeklyOnDutyMinutes + currentShiftMinutes
+
+    const drivingHours = +(weeklyDrivingMinutes / 60).toFixed(1)
+    const onDutyHours = +(totalOnDutyMinutes / 60).toFixed(1)
+
+    return NextResponse.json({
+      drivingHours,
+      onDutyHours,
+      weeklyDrivingHours: drivingHours,
+      currentShiftMinutes,
+      isOnShift: !!openShift,
+      warnings: {
+        approachingDrivingLimit: drivingHours >= WARN_DRIVING_HOURS && drivingHours < MAX_DRIVING_HOURS,
+        exceededDrivingLimit: drivingHours >= MAX_DRIVING_HOURS,
+        approachingOnDutyLimit: onDutyHours >= WARN_ONDUTY_HOURS && onDutyHours < MAX_ONDUTY_HOURS,
+        exceededOnDutyLimit: onDutyHours >= MAX_ONDUTY_HOURS,
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}

--- a/src/app/api/driver/status/route.ts
+++ b/src/app/api/driver/status/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/db"
-import { drivers } from "@/lib/schema"
+import { drivers, hosLogs } from "@/lib/schema"
 import { requireRole } from "@/lib/session"
 import { z } from "zod"
-import { eq } from "drizzle-orm"
+import { eq, isNull, and } from "drizzle-orm"
 
 const statusSchema = z.object({
   status: z.enum(["available", "on_shift", "driving", "delivering", "off_duty"]),
@@ -15,15 +15,36 @@ export async function PATCH(req: NextRequest) {
     const body = await req.json()
     const { status } = statusSchema.parse(body)
 
+    const [driver] = await db
+      .select({ id: drivers.id, status: drivers.status })
+      .from(drivers)
+      .where(eq(drivers.userId, session.user.id))
+      .limit(1)
+
+    if (!driver) {
+      return NextResponse.json({ error: "No driver profile found" }, { status: 404 })
+    }
+
+    const now = new Date()
+
+    // Open a shift log when going on_shift
+    if (status === "on_shift" && driver.status !== "on_shift") {
+      await db.insert(hosLogs).values({ driverId: driver.id, type: "shift", shiftStart: now })
+    }
+
+    // Close any open shift log when leaving on_shift
+    if (driver.status === "on_shift" && status !== "on_shift") {
+      await db
+        .update(hosLogs)
+        .set({ shiftEnd: now })
+        .where(and(eq(hosLogs.driverId, driver.id), eq(hosLogs.type, "shift"), isNull(hosLogs.shiftEnd)))
+    }
+
     const [updated] = await db
       .update(drivers)
       .set({ status })
-      .where(eq(drivers.userId, session.user.id))
+      .where(eq(drivers.id, driver.id))
       .returning()
-
-    if (!updated) {
-      return NextResponse.json({ error: "No driver profile found" }, { status: 404 })
-    }
 
     return NextResponse.json(updated)
   } catch (err) {

--- a/src/app/api/driver/trips/[id]/inspection/route.ts
+++ b/src/app/api/driver/trips/[id]/inspection/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { z } from "zod"
 import { eq, and } from "drizzle-orm"
 import { db } from "@/lib/db"
-import { tripInspections, trips, drivers } from "@/lib/schema"
+import { tripInspections, trips, drivers, hosLogs } from "@/lib/schema"
 import { requireRole } from "@/lib/session"
 import { auth } from "@/lib/auth"
 import { headers } from "next/headers"
@@ -69,7 +69,7 @@ export async function POST(
 
     // Verify the trip belongs to this driver
     const [trip] = await db
-      .select({ id: trips.id, status: trips.status })
+      .select({ id: trips.id, status: trips.status, startedAt: trips.startedAt })
       .from(trips)
       .where(and(eq(trips.id, tripId), eq(trips.driverId, driverId)))
       .limit(1)
@@ -93,10 +93,24 @@ export async function POST(
         .set({ status: "in_progress", startedAt: new Date() })
         .where(eq(trips.id, tripId))
     } else if (type === "post" && trip.status === "in_progress") {
+      const deliveredAt = new Date()
       await db
         .update(trips)
-        .set({ status: "delivered", deliveredAt: new Date() })
+        .set({ status: "delivered", deliveredAt })
         .where(eq(trips.id, tripId))
+
+      // Record driving time in HOS log
+      const drivingMinutes = trip.startedAt
+        ? Math.round((deliveredAt.getTime() - trip.startedAt.getTime()) / 60000)
+        : 0
+      await db.insert(hosLogs).values({
+        driverId,
+        tripId,
+        type: "driving",
+        shiftStart: trip.startedAt ?? deliveredAt,
+        shiftEnd: deliveredAt,
+        drivingMinutes,
+      })
     }
 
     return NextResponse.json({ inspection })

--- a/src/components/layouts/dispatcher-nav.tsx
+++ b/src/components/layouts/dispatcher-nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
-import { LayoutDashboard, MapPin, Truck, Bell, Map } from "lucide-react"
+import { LayoutDashboard, MapPin, Truck, Bell, Map, ClipboardList } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const navItems = [
@@ -12,6 +12,7 @@ const navItems = [
   { href: "/dispatch/fleet", label: "Fleet Status", icon: Truck },
   { href: "/dispatch/map", label: "Live Map", icon: Map },
   { href: "/dispatch/alerts", label: "Alerts", icon: Bell },
+  { href: "/dispatch/hos", label: "HOS Compliance", icon: ClipboardList },
 ]
 
 export function DispatcherNav() {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, boolean, index, doublePrecision, json } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean, index, doublePrecision, json, integer } from "drizzle-orm/pg-core";
 
 // IMPORTANT! ID fields should ALWAYS use UUID types, EXCEPT the BetterAuth tables.
 
@@ -276,6 +276,29 @@ export const tripInspections = pgTable(
   ]
 )
 
+export const hosLogs = pgTable(
+  "hos_logs",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    driverId: text("driver_id")
+      .notNull()
+      .references(() => drivers.id, { onDelete: "cascade" }),
+    // null for shift records; set for driving records linked to a trip
+    tripId: text("trip_id").references(() => trips.id, { onDelete: "set null" }),
+    // "shift" | "driving"
+    type: text("type").notNull(),
+    shiftStart: timestamp("shift_start"),
+    shiftEnd: timestamp("shift_end"),
+    // Populated for type="driving" when trip is delivered
+    drivingMinutes: integer("driving_minutes").notNull().default(0),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("hos_logs_driver_id_idx").on(table.driverId),
+    index("hos_logs_created_at_idx").on(table.createdAt),
+  ]
+)
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type User = typeof user.$inferSelect;
@@ -289,6 +312,7 @@ export type Message = typeof messages.$inferSelect;
 export type Notification = typeof notifications.$inferSelect;
 export type TripInspection = typeof tripInspections.$inferSelect;
 export type ProofOfDelivery = typeof proofOfDeliveries.$inferSelect;
+export type HosLog = typeof hosLogs.$inferSelect;
 export type UserRole = "admin" | "dispatcher" | "driver";
 export type TruckStatus = "available" | "on_trip" | "maintenance" | "inactive";
 export type DriverStatus = "available" | "on_shift" | "driving" | "delivering" | "off_duty";


### PR DESCRIPTION
## Summary
- Adds hos_logs table with two record types: shift (open/close on driver status change) and driving (logged per trip on post-trip inspection)
- Shift logs auto-open when driver goes on_shift, auto-close when leaving on_shift
- Driving minutes computed from trip startedAt to deliveredAt on post-trip inspection submit
- Driver home shows a 7-day HOS summary card: driving hours vs 11h limit, on-duty hours vs 14h limit, with orange (approaching) and red (exceeded) warnings
- Dispatcher gains a new HOS Compliance page (/dispatch/hos) showing all drivers with progress bars, status badges, and flag grouping

## Test plan
- [ ] As a driver, set status to On Shift — confirm a shift log is created
- [ ] Change status away from On Shift — confirm shift_end is recorded
- [ ] Complete a trip (pre + post inspection) — confirm a driving HOS log is inserted with correct minutes
- [ ] Check driver home page — HOS card shows driving and on-duty hours
- [ ] As dispatcher, open /dispatch/hos — all drivers listed with hours and progress bars
- [ ] Verify flags appear when a driver hours approach or exceed limits