### PR TITLE
Fix notification click navigation (issue #51)

### DIFF
--- a/src/components/notifications-bell.tsx
+++ b/src/components/notifications-bell.tsx
@@ -65,9 +65,9 @@ export function NotificationsBell() {
     return () => clearInterval(interval)
   }, [fetchNotifications])
 
-  async function handleClick(n: Notification) {
+  function handleClick(n: Notification) {
     if (!n.read) {
-      await fetch(`/api/notifications/${n.id}/read`, { method: "PATCH" })
+      fetch(`/api/notifications/${n.id}/read`, { method: "PATCH" }).catch(() => {})
       setItems((prev) => prev.map((item) => item.id === n.id ? { ...item, read: true } : item))
     }
     const link = getLink(n)


### PR DESCRIPTION
## Summary
- Notification clicks were broken because handleClick was async and awaited the mark-as-read fetch before calling router.push
- When DropdownMenuItem is clicked, Radix immediately closes/unmounts the dropdown — the async function was interrupted before router.push fired
- Fix: navigate immediately (synchronously), mark-as-read as fire-and-forget in the background

## Test plan
- [ ] Click a trip notification as driver — navigates to /driver/trips/:id
- [ ] Click a trip notification as dispatcher — navigates to /dispatch/trips/:id
- [ ] Notification is marked as read (blue dot disappears on next open)
- [ ] Test on mobile Safari and Edge