### PR TITLE
Add driver messages page

### DIFF
--- a/src/app/(driver)/driver/messages/page.tsx
+++ b/src/app/(driver)/driver/messages/page.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { toast } from "sonner"
+import { MessageSquare, ChevronRight } from "lucide-react"
+
+type ThreadRow = {
+  tripId: string
+  tripStatus: string
+  origin: string
+  destination: string
+  loadName: string | null
+  lastMessage: string
+  lastMessageAt: string
+  lastMessageSender: string
+  messageCount: number
+}
+
+function timeAgo(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return "just now"
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}
+
+export default function DriverMessagesPage() {
+  const [threads, setThreads] = useState<ThreadRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch("/api/driver/messages")
+      .then((r) => r.json())
+      .then((data) => { if (Array.isArray(data)) setThreads(data) })
+      .catch(() => toast.error("Failed to load messages"))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4 max-w-lg mx-auto">
+      <div>
+        <h1 className="text-xl font-bold">Messages</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">Conversations from your trips.</p>
+      </div>
+
+      {loading ? (
+        <div className="pt-16 text-center text-muted-foreground text-sm">Loading...</div>
+      ) : threads.length === 0 ? (
+        <div className="border rounded-xl p-12 text-center text-muted-foreground space-y-2">
+          <MessageSquare className="h-8 w-8 mx-auto opacity-30" />
+          <p className="text-sm">No messages yet.</p>
+          <p className="text-xs">Messages from your trips will appear here.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {threads.map((t) => (
+            <Link
+              key={t.tripId}
+              href={`/driver/trips/${t.tripId}`}
+              className="flex items-center gap-3 border rounded-xl p-4 hover:bg-muted/40 active:bg-muted/60 transition-colors"
+            >
+              <div className="flex-shrink-0 h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
+                <MessageSquare className="h-5 w-5 text-primary" />
+              </div>
+              <div className="flex-1 min-w-0 space-y-0.5">
+                <p className="font-medium text-sm truncate">{t.loadName ?? "Unknown load"}</p>
+                <p className="text-xs text-muted-foreground truncate">{t.origin} → {t.destination}</p>
+                <p className="text-xs text-muted-foreground truncate">
+                  <span className="font-medium">{t.lastMessageSender}:</span> {t.lastMessage}
+                </p>
+              </div>
+              <div className="flex flex-col items-end gap-1 shrink-0">
+                <span className="text-xs text-muted-foreground">{timeAgo(t.lastMessageAt)}</span>
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/driver/messages/route.ts
+++ b/src/app/api/driver/messages/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server"
+import { eq, desc, sql } from "drizzle-orm"
+import { db } from "@/lib/db"
+import { trips, drivers, chemicalLoads, user } from "@/lib/schema"
+import { requireRole } from "@/lib/session"
+
+export async function GET() {
+  try {
+    const { session } = await requireRole(["driver"])
+
+    const [driver] = await db
+      .select({ id: drivers.id })
+      .from(drivers)
+      .where(eq(drivers.userId, session.user.id))
+      .limit(1)
+
+    if (!driver) return NextResponse.json([])
+
+    // All trips for this driver that have at least one message
+    const rows = await db
+      .select({
+        tripId: trips.id,
+        tripStatus: trips.status,
+        origin: trips.origin,
+        destination: trips.destination,
+        loadName: chemicalLoads.name,
+        lastMessage: sql<string>`(
+          SELECT content FROM messages
+          WHERE trip_id = ${trips.id}
+          ORDER BY created_at DESC
+          LIMIT 1
+        )`.as("last_message"),
+        lastMessageAt: sql<string>`(
+          SELECT created_at FROM messages
+          WHERE trip_id = ${trips.id}
+          ORDER BY created_at DESC
+          LIMIT 1
+        )`.as("last_message_at"),
+        lastMessageSender: sql<string>`(
+          SELECT sender_name FROM messages
+          WHERE trip_id = ${trips.id}
+          ORDER BY created_at DESC
+          LIMIT 1
+        )`.as("last_message_sender"),
+        messageCount: sql<number>`(
+          SELECT COUNT(*) FROM messages WHERE trip_id = ${trips.id}
+        )`.as("message_count"),
+      })
+      .from(trips)
+      .leftJoin(chemicalLoads, eq(trips.loadId, chemicalLoads.id))
+      .leftJoin(user, eq(trips.createdBy, user.id))
+      .where(eq(trips.driverId, driver.id))
+      .orderBy(desc(sql`last_message_at`))
+
+    // Only return trips that have messages
+    const withMessages = rows.filter((r) => r.lastMessage)
+
+    return NextResponse.json(withMessages)
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes 404 on /driver/messages (Messages tab in driver bottom nav)
- Shows all trips with messages: last message preview, sender name, timestamp
- Tapping a thread navigates to the trip detail page which has the full message thread
- Empty state for drivers with no messages yet

## Test plan
- [ ] Tap Messages in driver bottom nav — no longer 404
- [ ] Trips with messages appear as threads with last message preview
- [ ] Tapping a thread opens the trip detail with the message thread
- [ ] Empty state shows when no messages exist