### PR TITLE
feat: isolated demo environment and demo guide

### DIFF
--- a/.env.demo.example
+++ b/.env.demo.example
@@ -1,0 +1,15 @@
+# Demo database — copy this to .env.demo and fill in your values
+POSTGRES_URL=postgresql://dev_user:dev_password@localhost:5433/postgres_demo
+
+BETTER_AUTH_SECRET=your-32-char-secret-here
+
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL="openai/gpt-5-mini"
+OPENAI_EMBEDDING_MODEL="text-embedding-3-large"
+
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+BLOB_READ_WRITE_TOKEN=
+BETTER_AUTH_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env*.example
 
 # vercel
 .vercel

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -1,0 +1,160 @@
+# TruckFleet — Demo Guide
+
+This guide walks you through running a live demo of TruckFleet using an **isolated demo database** so your real development data is never touched.
+
+---
+
+## One-Time Setup
+
+Run these once before your first demo.
+
+### 1. Start Docker
+```bash
+/Applications/Docker.app/Contents/Resources/bin/docker compose up -d
+```
+
+### 2. Create and migrate the demo database
+```bash
+pnpm demo:init
+```
+This creates a separate `postgres_demo` database inside the same Docker container and applies all migrations to it. Your `postgres_dev` data is untouched.
+
+### 3. Seed demo data
+```bash
+pnpm demo:seed
+```
+Populates the demo database with:
+- 5 user accounts (admin, dispatcher, 3 drivers)
+- 6 trucks across all statuses
+- 6 chemical loads with hazard classes and UN numbers
+- 5 trips across all lifecycle states (draft → delivered)
+- Messages on active trips
+- Pre/post inspections and proof of delivery on the completed trip
+- Simulated GPS coordinates for trucks in transit
+
+**Demo credentials — all use password `Demo1234!`**
+
+| Role | Email |
+|---|---|
+| Admin | admin@truckfleet.demo |
+| Dispatcher | dispatch@truckfleet.demo |
+| Driver 1 | driver1@truckfleet.demo |
+| Driver 2 | driver2@truckfleet.demo |
+| Driver 3 | driver3@truckfleet.demo |
+
+---
+
+## Starting the Demo
+
+```bash
+pnpm demo:start
+```
+
+This copies `.env.demo` to `.env.local` (which overrides `.env`) and starts the dev server pointing at `postgres_demo`. Open **http://localhost:3000**.
+
+---
+
+## Demo Walkthrough (~15 min)
+
+Use **three browser windows** side by side for maximum effect.
+
+---
+
+### Window 1 — Admin (`admin@truckfleet.demo`)
+
+**Chemical Loads → `/admin/loads`**
+- Show the load library: hazard classes, UN numbers, required certifications
+- Open a load → click Edit → scroll to SDS Document section → upload a PDF
+- Point out: a notification fires to the dispatcher window in real time
+
+**Trucks → `/admin/trucks`**
+- Show the fleet list with status badges (Available, On Trip, Maintenance)
+- Edit a truck — change its type or status
+
+**Drivers → `/admin/drivers`**
+- Show certifications (HazMat, TWIC, Tanker, etc.)
+- Explain that these gate which loads a driver can be assigned to
+
+---
+
+### Window 2 — Dispatcher (`dispatch@truckfleet.demo`)
+
+**Dashboard → `/dispatch`**
+- Summary cards: active trips, trucks available, drivers available, alerts
+- Show the notification bell — it received the SDS upload from the admin window
+
+**Trips → `/dispatch/trips`**
+- Filter by status to show all lifecycle stages
+- Open the in-progress trip — show load info, driver, truck, compliance data
+- **Create a new trip:**
+  - Select a chemical load
+  - Show that the driver dropdown only shows certified drivers
+  - Show that the truck dropdown only shows compatible vehicle types
+  - Save as draft or assign immediately
+
+**Live Map → `/dispatch/map`**
+- Truck pins on OpenStreetMap at real Texas highway coordinates
+- Show driver name, load, and status on each pin
+
+**Fleet Board → `/dispatch/fleet`**
+- At-a-glance availability of every truck and driver
+
+**Messages → `/dispatch/messages`**
+- Open a trip thread — send a message to the driver
+- Switch to Window 3 to show it arrive
+
+---
+
+### Window 3 — Driver on mobile (`driver1@truckfleet.demo`)
+
+> Open this in your phone browser or use Chrome DevTools device emulation
+
+**Home → `/driver`**
+- Today's trip card with origin, destination, chemical name
+- Status buttons (Available / On Shift / Driving / Delivering)
+
+**Trip Detail → `/driver/trips/[id]`**
+- Hazard class, UN number, handling notes
+- Navigate button → deep-links to Google Maps / Apple Maps
+- Pre-trip inspection checklist → submit → Start Trip button unlocks
+- Send a message to dispatcher → confirm it appears in Window 2
+
+**Documents → `/driver/documents`**
+- Show the SDS PDF link from the admin upload in Window 1
+- Tap to open the PDF
+
+**Install as PWA (bonus)**
+- Safari on iPhone: Share → Add to Home Screen
+- Show the home screen icon and bottom navigation
+
+---
+
+## Resetting Between Demos
+
+To restore the database to a clean state at any time:
+```bash
+pnpm demo:seed
+```
+
+This wipes all domain data and re-inserts the full demo dataset. Takes ~5 seconds.
+
+---
+
+## Stopping the Demo
+
+```bash
+# Stop the dev server (Ctrl+C), then:
+pnpm demo:stop
+```
+
+This removes `.env.local`, switching the app back to your real `postgres_dev` database. Run `pnpm dev` as normal after this.
+
+---
+
+## Tips
+
+- **SDS upload + notification** is the most impressive live interaction — do this early with both windows visible
+- **Messages** between dispatcher and driver windows shows the real-time feel
+- **Trip creation with cert filtering** is a key differentiator — show the dropdown only populating valid drivers after selecting a load
+- **Mobile PWA install** is a strong finish for showing the driver experience
+- If anything looks broken, `pnpm demo:seed` resets everything in seconds

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "db:studio": "drizzle-kit studio",
     "db:dev": "drizzle-kit push",
     "db:reset": "drizzle-kit drop && drizzle-kit push",
-    "db:seed": "tsx --env-file=.env scripts/seed.ts"
+    "db:seed": "tsx --env-file=.env scripts/seed.ts",
+    "demo:init": "tsx --env-file=.env.demo scripts/demo-init.ts",
+    "demo:seed": "tsx --env-file=.env.demo scripts/seed.ts",
+    "demo:start": "cp .env.demo .env.local && next dev --turbopack",
+    "demo:stop": "rm -f .env.local"
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.125",

--- a/scripts/demo-init.ts
+++ b/scripts/demo-init.ts
@@ -1,0 +1,49 @@
+/**
+ * One-time demo database setup.
+ * Creates the postgres_demo database and runs all migrations.
+ * Run with: pnpm demo:init
+ */
+
+import { drizzle } from "drizzle-orm/postgres-js"
+import { migrate } from "drizzle-orm/postgres-js/migrator"
+import postgres from "postgres"
+
+const demoUrl = process.env.POSTGRES_URL!
+// Connect to the default postgres_dev DB to create postgres_demo
+const adminUrl = demoUrl.replace("/postgres_demo", "/postgres_dev")
+
+async function init() {
+  console.log("🔧 Setting up demo database...\n")
+
+  // Create the demo database if it doesn't exist
+  const adminClient = postgres(adminUrl, { max: 1 })
+  try {
+    await adminClient`CREATE DATABASE postgres_demo`
+    console.log("  ✓ Created postgres_demo database")
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message.includes("already exists")) {
+      console.log("  ✓ postgres_demo already exists")
+    } else {
+      throw e
+    }
+  } finally {
+    await adminClient.end()
+  }
+
+  // Run migrations against the demo database
+  const client = postgres(demoUrl, { max: 1 })
+  const db = drizzle(client)
+  try {
+    await migrate(db, { migrationsFolder: "./drizzle" })
+    console.log("  ✓ Migrations applied")
+  } finally {
+    await client.end()
+  }
+
+  console.log("\n✅ Demo database ready. Run pnpm demo:seed to populate it.\n")
+}
+
+init().catch((err) => {
+  console.error("❌ Demo init failed:", err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Adds a completely isolated demo database (`postgres_demo`) so demo data never touches dev data
- One command to init, one to seed, one to start, one to stop

## New scripts
| Command | What it does |
|---|---|
| `pnpm demo:init` | One-time: creates `postgres_demo` DB + runs migrations |
| `pnpm demo:seed` | Populates demo data (re-run anytime to reset) |
| `pnpm demo:start` | Starts app pointed at demo DB via `.env.local` |
| `pnpm demo:stop` | Removes `.env.local`, restores normal dev DB |

## New files
- `.env.demo.example` — template to copy to `.env.demo`
- `scripts/demo-init.ts` — creates DB + migrates programmatically
- `docs/demo-guide.md` — full demo walkthrough with credentials, window layout, reset steps

## Test plan
- [ ] CI passes
- [ ] `pnpm demo:init` creates `postgres_demo` and applies migrations
- [ ] `pnpm demo:seed` populates all demo data
- [ ] `pnpm demo:start` serves app against demo DB
- [ ] `pnpm demo:stop` restores `.env` / removes `.env.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)